### PR TITLE
:sparkles: Feat: add kakao sign in to get access token

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     implementation(libs.ui.graphics)
     implementation(libs.ui.tooling.preview)
     implementation(libs.material3)
+    implementation(libs.identity.credential.android)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.test.ext.junit)
     androidTestImplementation(libs.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,20 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <!-- Redirect URI: "kakao${NATIVE_APP_KEY}://oauth" -->
+                <data android:host="oauth"
+                    android:scheme="@string/kakao_oauth_host" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/sowhat/justsayit/JustSayItApplication.kt
+++ b/app/src/main/java/com/sowhat/justsayit/JustSayItApplication.kt
@@ -1,6 +1,9 @@
 package com.sowhat.justsayit
 
 import android.app.Application
+import android.util.Log
+import com.kakao.sdk.common.KakaoSdk
+import com.kakao.sdk.common.util.Utility
 import com.navercorp.nid.NaverIdLoginSDK
 import dagger.hilt.android.HiltAndroidApp
 
@@ -8,11 +11,28 @@ import dagger.hilt.android.HiltAndroidApp
 class JustSayItApplication : Application() {
     override fun onCreate() {
         super.onCreate()
+
+        initNaverSignIn()
+        initKakaoSignIn()
+
+        val keyHash = Utility.getKeyHash(this)
+        Log.i(TAG, keyHash)
+    }
+
+    private fun initNaverSignIn() {
         NaverIdLoginSDK.initialize(
             context = this,
             clientId = BuildConfig.NAVER_CLIENT_ID,
             clientSecret = BuildConfig.NAVER_CLIENT_SECRET,
             clientName = resources.getString(R.string.app_name)
         )
+    }
+
+    private fun initKakaoSignIn() {
+        KakaoSdk.init(this, BuildConfig.KAKAO_NATIVE_APP_KEY)
+    }
+
+    companion object {
+        const val TAG = "JustSayItApplication"
     }
 }

--- a/authentication/authentication-presentation/src/main/java/com/sowhat/presentation/onboarding/OnboardingScreen.kt
+++ b/authentication/authentication-presentation/src/main/java/com/sowhat/presentation/onboarding/OnboardingScreen.kt
@@ -22,6 +22,7 @@ import com.sowhat.presentation.component.Logo
 import com.sowhat.presentation.component.SignIn
 import com.sowhat.presentation.component.TermText
 import com.sowhat.presentation.navigation.navigateToUserConfig
+import com.sowhat.util.KakaoOAuthClient
 import com.sowhat.util.NaverOAuthClient
 import kotlinx.coroutines.launch
 
@@ -37,10 +38,22 @@ fun OnboardingScreen(
     modifier: Modifier = Modifier,
     navController: NavHostController
 ) {
+    val TAG = "OnboardingScreen"
+
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
 
     val signInPlatforms = listOf(
+        SignInPlatform(
+            iconDrawable = R.drawable.ic_kakao_54,
+            onClick = {
+                scope.launch {
+                    val accessToken = KakaoOAuthClient.signIn(context)
+                    Log.i(TAG, "kakao access token : $accessToken")
+                    if (accessToken != null) navController.navigateToUserConfig()
+                }
+            }
+        ),
         SignInPlatform(
             iconDrawable = R.drawable.ic_naver_54,
             onClick = {

--- a/authentication/authentication-presentation/src/main/java/com/sowhat/util/KakaoOAuthClient.kt
+++ b/authentication/authentication-presentation/src/main/java/com/sowhat/util/KakaoOAuthClient.kt
@@ -1,0 +1,55 @@
+package com.sowhat.util
+
+import android.content.Context
+import android.util.Log
+import com.kakao.sdk.auth.model.OAuthToken
+import com.kakao.sdk.common.model.ClientError
+import com.kakao.sdk.common.model.ClientErrorCause
+import com.kakao.sdk.user.UserApiClient
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+object KakaoOAuthClient {
+    val TAG = "KakaoAuthClient"
+
+    suspend fun signIn(context: Context): String? {
+        return kakaoAuthentication(context)?.accessToken
+    }
+
+    private suspend fun kakaoAuthentication(context: Context) = suspendCoroutine { continuation ->
+
+        val callback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
+            if (error != null) {
+                Log.e(TAG, "카카오계정으로 로그인 실패", error)
+                continuation.resume(token)
+
+            } else if (token != null) {
+                Log.i(TAG, "카카오계정으로 로그인 성공 ${token.accessToken}")
+                continuation.resume(null)
+            }
+        }
+
+        if (UserApiClient.instance.isKakaoTalkLoginAvailable(context)) {
+            UserApiClient.instance.loginWithKakaoTalk(context) { token, error ->
+                if (error != null) {
+                    Log.e(TAG, "카카오톡으로 로그인 실패", error)
+
+                    // 사용자가 카카오톡 설치 후 디바이스 권한 요청 화면에서 로그인을 취소한 경우,
+                    // 의도적인 로그인 취소로 보고 카카오계정으로 로그인 시도 없이 로그인 취소로 처리 (예: 뒤로 가기)
+                    if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
+                        continuation.resume(null)
+                        return@loginWithKakaoTalk
+                    }
+
+                    // 카카오톡에 연결된 카카오계정이 없는 경우, 카카오계정으로 로그인 시도
+                    UserApiClient.instance.loginWithKakaoAccount(context, callback = callback)
+                } else if (token != null) {
+                    Log.i(TAG, "카카오톡으로 로그인 성공 ${token.accessToken}")
+                    continuation.resume(token)
+                }
+            }
+        } else {
+            UserApiClient.instance.loginWithKakaoAccount(context, callback = callback)
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/com/sowhat/convention/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/sowhat/convention/KotlinAndroid.kt
@@ -38,9 +38,15 @@ internal fun Project.configureKotlinAndroid() {
         buildTypes {
             val naverClientId = project.properties["NAVER_CLIENT_ID"]
             val naverClientSecret = project.properties["NAVER_CLIENT_SECRET"]
+
+            val kakaoNativeAppKey = project.properties["KAKAO_NATIVE_APP_KEY"]
+            val kakaoOAuthHost = project.properties["KAKAO_OAUTH_HOST"]
+
             getByName("debug") {
                 buildConfigField("String", "NAVER_CLIENT_ID", naverClientId.toString())
                 buildConfigField("String", "NAVER_CLIENT_SECRET", naverClientSecret.toString())
+                buildConfigField("String", "KAKAO_NATIVE_APP_KEY", kakaoNativeAppKey.toString())
+                resValue("string", "kakao_oauth_host", kakaoOAuthHost.toString())
             }
 
             getByName("release") {

--- a/build-logic/convention/src/main/kotlin/com/sowhat/convention/OAuthPlatforms.kt
+++ b/build-logic/convention/src/main/kotlin/com/sowhat/convention/OAuthPlatforms.kt
@@ -10,5 +10,7 @@ internal fun Project.configureOAuthPlatforms() {
 //    Extensions
     dependencies {
         add("implementation", libs.findLibrary("nid.oauth").get())
+        implementation(libs, "kakao.sdk")
+
     }
 }

--- a/core/designsystem/src/main/res/drawable/ic_google_54.xml
+++ b/core/designsystem/src/main/res/drawable/ic_google_54.xml
@@ -1,0 +1,30 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="54dp"
+    android:height="54dp"
+    android:viewportWidth="54"
+    android:viewportHeight="54">
+  <path
+      android:strokeWidth="1"
+      android:pathData="M27,0.5L27,0.5A26.5,26.5 0,0 1,53.5 27L53.5,27A26.5,26.5 0,0 1,27 53.5L27,53.5A26.5,26.5 0,0 1,0.5 27L0.5,27A26.5,26.5 0,0 1,27 0.5z"
+      android:fillColor="#ffffff"
+      android:strokeColor="#EEEEEE"/>
+  <path
+      android:pathData="M30.561,27.703L23.146,17H17V37H23.439V26.295L30.854,37H37V17H30.561V27.703Z"
+      android:fillColor="#ffffff"/>
+  <path
+      android:pathData="M38.54,27.761C38.54,26.946 38.467,26.162 38.331,25.409H27.5V29.858H33.689C33.423,31.295 32.612,32.513 31.394,33.328V36.214H35.111C37.285,34.212 38.54,31.264 38.54,27.761Z"
+      android:fillColor="#4285F4"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M27.5,39C30.605,39 33.208,37.97 35.111,36.213L31.394,33.328C30.365,34.018 29.047,34.426 27.5,34.426C24.505,34.426 21.969,32.403 21.065,29.685H17.223V32.664C19.115,36.423 23.004,39 27.5,39Z"
+      android:fillColor="#34A853"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M21.065,29.685C20.835,28.996 20.705,28.258 20.705,27.5C20.705,26.743 20.835,26.006 21.065,25.316V22.336H17.223C16.444,23.888 16,25.645 16,27.5C16,29.356 16.444,31.112 17.223,32.665L21.065,29.685Z"
+      android:fillColor="#FBBC05"
+      android:fillType="evenOdd"/>
+  <path
+      android:pathData="M27.5,20.574C29.188,20.574 30.704,21.154 31.896,22.294L35.194,18.995C33.203,17.139 30.6,16 27.5,16C23.004,16 19.115,18.577 17.223,22.336L21.065,25.315C21.969,22.597 24.505,20.574 27.5,20.574Z"
+      android:fillColor="#EA4335"
+      android:fillType="evenOdd"/>
+</vector>

--- a/core/designsystem/src/main/res/drawable/ic_kakao_54.xml
+++ b/core/designsystem/src/main/res/drawable/ic_kakao_54.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="54dp"
+    android:height="54dp"
+    android:viewportWidth="54"
+    android:viewportHeight="54">
+  <path
+      android:pathData="M27,0L27,0A27,27 0,0 1,54 27L54,27A27,27 0,0 1,27 54L27,54A27,27 0,0 1,0 27L0,27A27,27 0,0 1,27 0z"
+      android:fillColor="#FEE500"/>
+  <path
+      android:pathData="M26.952,17C20.903,17 16,20.706 16,25.277C16,28.119 17.896,30.625 20.784,32.115L19.569,36.458C19.462,36.841 19.91,37.147 20.255,36.925L25.581,33.486C26.031,33.528 26.488,33.553 26.952,33.553C33.001,33.553 37.905,29.847 37.905,25.277C37.905,20.706 33.001,17 26.952,17Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
+</vector>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,6 +42,7 @@ material = "1.11.0"
 
 # 네이버 sdk -> 왜 버전이 인식이 안되는것인가?
 nidOauth = "5.9.0"
+kakaoSdk = "2.19.0"
 
 [libraries]
 # for gradle plugins -> for build-logic/build.gradle dependencies
@@ -105,6 +106,10 @@ material = { group = "com.google.android.material", name = "material", version.r
 # naver oauth
 nid-oauth = { group = "com.navercorp.nid", name = "oauth-jdk8", version.ref = "nidOauth" }
 androidx-navigation-common-ktx = { group = "androidx.navigation", name = "navigation-common-ktx", version = "2.7.6" }
+identity-credential-android = { group = "com.android.identity", name = "identity-credential-android", version = "20231002" }
+
+# kakao auth
+kakao-sdk = { group = "com.kakao.sdk", name = "v2-user", version.ref = "kakaoSdk" }
 
 [plugins]
 com-android-application = { id = "com.android.application", version.ref = "agp" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url = uri("https://devrepo.kakao.com/nexus/content/groups/public/") }
     }
 }
 


### PR DESCRIPTION
* 카카오로 로그인하기 구현을 위한 작업 진행
  * kakao developers에 안드로이드 프로젝트 등록
  * 등록한 애플리케이션의 네이티브 앱 키, 카카오 인증 호스트 변수를 gradle.properties에 저장(보안 상 이유로 gitignore 처리
  * kakao sdk를 통해, 네이티브 앱키를 활용하여 카카오 로그인을 초기화하고 manifest에서 카카오 인증 호스트를 스키마에 등록
  * KakaoOAuthClient 객체에 카카오 로그인 로직을 두어, access token을 반환하는 메소드를 추가