### PR TITLE
✨ Feat: add google sign in to get id token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,4 @@ gradle.properties
 *.keystore
 
 # Google Services (e.g. APIs or Firebase)
-google-services.json
+app/google-services.json

--- a/authentication/authentication-presentation/src/main/java/com/sowhat/util/GoogleOAuthClient.kt
+++ b/authentication/authentication-presentation/src/main/java/com/sowhat/util/GoogleOAuthClient.kt
@@ -1,0 +1,111 @@
+package com.sowhat.util
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.content.IntentSender
+import android.util.Log
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import com.google.android.gms.auth.api.identity.BeginSignInRequest
+import com.google.android.gms.auth.api.identity.BeginSignInRequest.GoogleIdTokenRequestOptions
+import com.google.android.gms.auth.api.identity.SignInClient
+import com.google.firebase.auth.GoogleAuthProvider
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.ktx.Firebase
+import com.sowhat.authentication_presentation.BuildConfig
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+import java.util.concurrent.CancellationException
+
+class GoogleOAuthClient(
+    private val context: Context,
+    private val oneTapClient: SignInClient
+) {
+
+    companion object {
+        const val TAG = "GoogleAuthClient"
+    }
+
+    private val auth = Firebase.auth
+
+    suspend fun signIn(): IntentSender? {
+        val result = try {
+            // beginSignIn : returns a task
+            Log.d(TAG, "Google Sign In entering")
+            oneTapClient.beginSignIn(
+                // BeginSignInRequest 클래스가 매개변수
+                buildSignInRequest()
+            ).await()
+
+
+        } catch(e: Exception) {
+            Log.d(TAG, "Google Sign In exception ${e.message}")
+            if (e is CancellationException) throw e
+            null
+        }
+
+        // intentSender
+        // application will get intent 'back' with the information about user sign in
+
+        Log.d(TAG, "Google Sign In ended ${result}")
+        return result?.pendingIntent?.intentSender
+    }
+
+    // the function to deserialize the intent from signIn(), for getting real information
+    suspend fun signInWithIntent(intent: Intent): String? {
+        // can be directly derived from intent
+        val credential = oneTapClient.getSignInCredentialFromIntent(intent)
+        val googleIdToken = credential.googleIdToken
+        Log.d(TAG, "google token : $googleIdToken")
+        // googleIdToken을 이용하여, 실제로 로그인
+
+        return googleIdToken
+    }
+
+    private fun buildSignInRequest(): BeginSignInRequest {
+        Log.d(TAG, "buildSignInRequest started")
+        return BeginSignInRequest.builder()
+            .setGoogleIdTokenRequestOptions(
+                GoogleIdTokenRequestOptions.builder()
+                    .setSupported(true) // google authenticating by google token id is supported
+                    .setFilterByAuthorizedAccounts(false)
+                    .setServerClientId(BuildConfig.GOOGLE_WEB_CLIENT_ID)
+                    .build()
+            )
+            .setAutoSelectEnabled(true) // 디바이스에 구글 계정이 오직 하나라면 자동으로 그 계정 선택
+            .build()
+    }
+
+    suspend fun signOut() {
+        try {
+            oneTapClient.signOut().await()
+            auth.signOut()
+        } catch(e: Exception) {
+            e.printStackTrace()
+            if (e is CancellationException) throw e
+        }
+    }
+}
+
+
+
+/*
+* the class for signing in, signing out, getting user info
+
+* constructors
+    * context
+    * oneTapClient: SignInClient
+        => the client that comes from firebase sdk
+        => for showing the dialog to select ids
+* member variables
+    * auth : as a global variable of this class
+        * for getting functions related to authentication(signin, signout) from Firebase
+* functions
+    * signIn (as a suspend function -> 로그인에는 특정 시간이 걸리며, 그 시간 동안에는 잠시 다른 작업은 멈추어야 함)
+        * returns an IntentSender; An Object to send out an Intent(delegation to firebase)
+
+* By Default, All Firebase Functions return a "task"(asynchronous)
+    * about task in android...
+        *
+ */

--- a/build-logic/convention/src/main/kotlin/com/sowhat/convention/Extensions.kt
+++ b/build-logic/convention/src/main/kotlin/com/sowhat/convention/Extensions.kt
@@ -29,6 +29,10 @@ internal fun DependencyHandlerScope.implementation(libs: VersionCatalog, depende
     add("implementation", libs.findLibrary(dependency).get())
 }
 
+internal fun DependencyHandlerScope.platformImplementation(libs: VersionCatalog, dependency: String) {
+    add("implementation", platform(libs.findLibrary(dependency).get()))
+}
+
 internal fun DependencyHandlerScope.kapt(libs: VersionCatalog, dependency: String) {
     add("kapt", libs.findLibrary(dependency).get())
 }

--- a/build-logic/convention/src/main/kotlin/com/sowhat/convention/KotlinAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/sowhat/convention/KotlinAndroid.kt
@@ -42,11 +42,14 @@ internal fun Project.configureKotlinAndroid() {
             val kakaoNativeAppKey = project.properties["KAKAO_NATIVE_APP_KEY"]
             val kakaoOAuthHost = project.properties["KAKAO_OAUTH_HOST"]
 
+            val googleWebClientId = project.properties["GOOGLE_WEB_CLIENT_ID"]
+
             getByName("debug") {
                 buildConfigField("String", "NAVER_CLIENT_ID", naverClientId.toString())
                 buildConfigField("String", "NAVER_CLIENT_SECRET", naverClientSecret.toString())
                 buildConfigField("String", "KAKAO_NATIVE_APP_KEY", kakaoNativeAppKey.toString())
                 resValue("string", "kakao_oauth_host", kakaoOAuthHost.toString())
+                buildConfigField("String", "GOOGLE_WEB_CLIENT_ID", googleWebClientId.toString())
             }
 
             getByName("release") {

--- a/build-logic/convention/src/main/kotlin/com/sowhat/convention/OAuthPlatforms.kt
+++ b/build-logic/convention/src/main/kotlin/com/sowhat/convention/OAuthPlatforms.kt
@@ -8,9 +8,16 @@ import org.gradle.kotlin.dsl.dependencies
 internal fun Project.configureOAuthPlatforms() {
     val libs = extensions.libs
 //    Extensions
+    pluginManager.apply {
+        apply("com.google.gms.google-services")
+    }
+
     dependencies {
         add("implementation", libs.findLibrary("nid.oauth").get())
         implementation(libs, "kakao.sdk")
-
+        implementation(libs, "firebase.analytics")
+        platformImplementation(libs, "firebase.bom")
+        implementation(libs, "firebase.auth.ktx")
+        implementation(libs, "play.services.auth")
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,11 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
+    dependencies {
+        classpath(libs.google.services)
+        // for serialization
+        classpath(libs.kotlin.serialization)
+    }
+
     repositories {
         google()
         mavenCentral()
@@ -14,5 +20,7 @@ plugins {
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.org.jetbrains.kotlin.jvm) apply false
     alias(libs.plugins.com.android.library) apply false
+    alias(libs.plugins.google.services) apply false
+
 }
 true // Needed to make the Suppress annotation work for the plugins block

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ androidGradlePlugin = "8.0.2"
 androidxComposeCompiler = "1.4.3"
 
 agp = "8.1.0-rc01"
+googleServices = "4.4.0"
 kotlin = "1.8.10"
 core-ktx = "1.9.0"
 junit = "4.13.2"
@@ -44,15 +45,22 @@ material = "1.11.0"
 nidOauth = "5.9.0"
 kakaoSdk = "2.19.0"
 
+# firebase
+firebaseBom = "32.7.0"
+firebaseAuthKtx = "22.3.0"
+playServicesAuth = "20.7.0"
+
 [libraries]
 # for gradle plugins -> for build-logic/build.gradle dependencies
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "androidGradlePlugin" }
+google-services = { module = "com.google.gms:google-services", version.ref = "googleServices" }
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidx-test-ext-junit" }
 espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso-core" }
+kotlin-serialization = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlin" }
 lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle-runtime-ktx" }
 activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
@@ -111,6 +119,14 @@ identity-credential-android = { group = "com.android.identity", name = "identity
 # kakao auth
 kakao-sdk = { group = "com.kakao.sdk", name = "v2-user", version.ref = "kakaoSdk" }
 
+# firebase for oauth
+firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics" }
+### platform
+firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
+firebase-auth-ktx = { group = "com.google.firebase", name = "firebase-auth-ktx", version.ref = "firebaseAuthKtx" }
+play-services-auth = { group = "com.google.android.gms", name = "play-services-auth", version.ref = "playServicesAuth" }
+
+
 [plugins]
 com-android-application = { id = "com.android.application", version.ref = "agp" }
 org-jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
@@ -119,5 +135,6 @@ kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 org-jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "org-jetbrains-kotlin-jvm" }
 com-android-library = { id = "com.android.library", version.ref = "agp" }
+google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
 
 [bundles]


### PR DESCRIPTION
* 구글로 로그인하기 구현을 위한 제반 사항 구현
  * firebase에 프로젝트 등록(패키지명, SHA-1 등) -> google-services.json 파일을 app 모듈에 담음
  * firebase, gms, google play 관련 dependencies 추가
  * firebase 프로젝트에서 구글 로그인 활성화 후, client id를 받아 gradle.properties의 변수로 추가(보안상 이유로 gitignore 처리)
  * GoogleOAuthClient 객체에서 원탭 구글 로그인 동작을 하는 메소드와 로그인 성공 시 토큰을 반환하는 메소드 구현
  * OnboardingScreen에서 구글 로그인 버튼 추가
  * OnboardingScreen에서 GoogleOAuthClient의 메소드를 활용하여 로그인 작업 진행