### PR TITLE
✨ Feat: add image compression work manager for background compression

### DIFF
--- a/app/src/main/java/com/sowhat/justsayit/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/sowhat/justsayit/navigation/AppNavHost.kt
@@ -4,7 +4,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
-import com.sowhat.common.ONBOARDING
+import com.sowhat.common.navigation.ONBOARDING
 import com.sowhat.main_presentation.navigation.mainScreen
 import com.sowhat.presentation.navigation.onBoardingScreen
 import com.sowhat.presentation.navigation.userConfigScreen

--- a/authentication/authentication-presentation/src/main/java/com/sowhat/presentation/navigation/AuthNavigation.kt
+++ b/authentication/authentication-presentation/src/main/java/com/sowhat/presentation/navigation/AuthNavigation.kt
@@ -5,12 +5,11 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
-import com.sowhat.common.CONFIGURATION
-import com.sowhat.common.MAIN
-import com.sowhat.common.ONBOARDING
+import com.sowhat.common.navigation.CONFIGURATION
+import com.sowhat.common.navigation.MAIN
+import com.sowhat.common.navigation.ONBOARDING
 import com.sowhat.presentation.configuration.UserConfigRoute
 import com.sowhat.presentation.onboarding.OnboardingRoute
-import com.sowhat.presentation.onboarding.OnboardingScreen
 
 fun NavGraphBuilder.onBoardingScreen(
     navController: NavHostController

--- a/build-logic/convention/src/main/kotlin/com/sowhat/convention/CommonLibraries.kt
+++ b/build-logic/convention/src/main/kotlin/com/sowhat/convention/CommonLibraries.kt
@@ -33,5 +33,8 @@ internal fun Project.configureCommonLibraries() {
 
         implementation(libs, "paging.compose")
         implementation(libs, "paging.runtime.ktx")
+
+        implementation(libs, "work.runtime.ktx")
+        implementation(libs, "compose.livedata")
     }
 }

--- a/core/common/src/main/java/com/sowhat/common/navigation/ImageCompression.kt
+++ b/core/common/src/main/java/com/sowhat/common/navigation/ImageCompression.kt
@@ -1,0 +1,3 @@
+package com.sowhat.common.navigation
+
+const val VALUE_COMPRESSION_KILOBYTES = 1024 * 1000 // 1mb

--- a/core/common/src/main/java/com/sowhat/common/navigation/Route.kt
+++ b/core/common/src/main/java/com/sowhat/common/navigation/Route.kt
@@ -1,4 +1,4 @@
-package com.sowhat.common
+package com.sowhat.common.navigation
 
 const val SPLASH = "splash"
 const val ONBOARDING = "onboarding"

--- a/core/common/src/main/java/com/sowhat/common/util/ImageCompressionWorker.kt
+++ b/core/common/src/main/java/com/sowhat/common/util/ImageCompressionWorker.kt
@@ -1,0 +1,69 @@
+package com.sowhat.common.util
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import androidx.work.workDataOf
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.io.ByteArrayOutputStream
+import java.io.File
+import kotlin.math.roundToInt
+
+class ImageCompressionWorker(
+    private val appContext: Context,
+    private val params: WorkerParameters
+) : CoroutineWorker(appContext, params) {
+    override suspend fun doWork(): Result {
+        return withContext(Dispatchers.IO) {
+            val inputImageStringUri = params.inputData.getString(KEY_IMAGE_URI)
+            val compressionKilobytes = params.inputData.getLong(
+                KEY_COMPRESSION_KILOBYTES,
+                0L
+            )
+
+            val inputImageUri = Uri.parse(inputImageStringUri)
+            val inputImageBytes = appContext.contentResolver.openInputStream(inputImageUri)?.use {
+                it.readBytes()
+            } ?: return@withContext Result.failure()
+
+            // original bitmap
+
+            val bitmap = BitmapFactory.decodeByteArray(
+                inputImageBytes,
+                0,
+                inputImageBytes.size
+            )
+
+            // compression
+            var outputBytes: ByteArray
+            var quality = 100 // compress 메소드의 quality -> 0부터 100까지. 100이 원본에 가깝고 0이 가장 낮은 화질
+            do {
+                val outputStream = ByteArrayOutputStream()
+                outputStream.use { ost ->
+                    bitmap.compress(Bitmap.CompressFormat.JPEG, quality, ost)
+                    outputBytes = ost.toByteArray()
+                    quality -= (quality * 0.1).roundToInt()
+                }
+            } while(outputBytes.size > compressionKilobytes && quality > 40)
+
+            val file = File(appContext.cacheDir, "${params.id}.jpg")
+            file.writeBytes(outputBytes)
+
+            Result.success(
+                workDataOf(
+                    KEY_RESULT_URI to file.absolutePath
+                )
+            )
+        }
+    }
+
+    companion object {
+        const val KEY_IMAGE_URI = "KEY_IMAGE_URI"
+        const val KEY_COMPRESSION_KILOBYTES = "KEY_COMPRESSION_KILOBYTES"
+        const val KEY_RESULT_URI = "KEY_RESULT_URI"
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ espresso-core = "3.5.1"
 lifecycle-runtime-ktx = "2.6.2"
 activity-compose = "1.8.2"
 compose-bom = "2023.03.00"
+composeRuntime = "1.5.4"
 constraintLayout = "1.0.1"
 
 hilt = "2.48"
@@ -49,6 +50,8 @@ kakaoSdk = "2.19.0"
 firebaseBom = "32.7.0"
 firebaseAuthKtx = "22.3.0"
 playServicesAuth = "20.7.0"
+
+work = "2.8.0"
 
 [libraries]
 # for gradle plugins -> for build-logic/build.gradle dependencies
@@ -126,6 +129,10 @@ firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.r
 firebase-auth-ktx = { group = "com.google.firebase", name = "firebase-auth-ktx", version.ref = "firebaseAuthKtx" }
 play-services-auth = { group = "com.google.android.gms", name = "play-services-auth", version.ref = "playServicesAuth" }
 
+# workmanager
+work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "work" }
+
+compose-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata", version.ref = "composeRuntime"}
 
 [plugins]
 com-android-application = { id = "com.android.application", version.ref = "agp" }

--- a/main/main-presentation/src/main/java/com/sowhat/main_presentation/navigation/MainNavigation.kt
+++ b/main/main-presentation/src/main/java/com/sowhat/main_presentation/navigation/MainNavigation.kt
@@ -3,7 +3,7 @@ package com.sowhat.main_presentation.navigation
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
-import com.sowhat.common.MAIN
+import com.sowhat.common.navigation.MAIN
 import com.sowhat.main_presentation.ui.MainRoute
 
 fun NavGraphBuilder.mainScreen(

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/navigation/UserNavigation.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/navigation/UserNavigation.kt
@@ -2,8 +2,8 @@ package com.sowhat.user_presentation.navigation
 
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
-import com.sowhat.common.CONFIG_EDIT
-import com.sowhat.common.SETTING
+import com.sowhat.common.navigation.CONFIG_EDIT
+import com.sowhat.common.navigation.SETTING
 import com.sowhat.user_presentation.edit.EditRoute
 import com.sowhat.user_presentation.setting.SettingRoute
 


### PR DESCRIPTION
* 백그라운드에서 이미지 압축을 진행하기 위한 workmanager를 구현
  * work 의존성 추가
  * workmanager 객체 추가
    * 이미지 자체를 workmanager와 주고받는데는 무리가 있으므로, 이미지 거래는 string 형태의 uri를 활용
    * inputData : 원본 이미지의 uri, 한계 용량(kilobyte 단위)
    * outputData : 압축된 이미지의 uri의 문자열 형태
      * cacheDir에 임시적으로 저장해놓고, 외부에서 해당 uri를 활용하여 이미지를 활용