### PR TITLE
💄 Design: update user info related components and layouts

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -12,6 +12,6 @@
         </deviceKey>
       </Target>
     </targetSelectedWithDropDown>
-    <timeTargetWasSelectedWithDropDown value="2024-01-08T04:49:55.979474300Z" />
+    <timeTargetWasSelectedWithDropDown value="2024-01-14T16:59:57.183852100Z" />
   </component>
 </project>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,7 +29,8 @@
 
         <activity
             android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
-            android:exported="true">
+            android:exported="true"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/app/src/main/java/com/sowhat/justsayit/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/sowhat/justsayit/navigation/AppNavHost.kt
@@ -4,6 +4,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
+import com.sowhat.common.navigation.CONFIGURATION
 import com.sowhat.common.navigation.ONBOARDING
 import com.sowhat.main_presentation.navigation.mainScreen
 import com.sowhat.presentation.navigation.onBoardingScreen
@@ -15,7 +16,7 @@ fun AppNavHost(
     navController: NavHostController,
     snackbarHostState: SnackbarHostState
 ) {
-    NavHost(navController = navController, startDestination = ONBOARDING) {
+    NavHost(navController = navController, startDestination = CONFIGURATION) {
         onBoardingScreen(navController = navController)
         userConfigScreen(navController = navController)
         configEditScreen()

--- a/authentication/authentication-presentation/src/main/java/com/sowhat/presentation/common/TextFieldInfo.kt
+++ b/authentication/authentication-presentation/src/main/java/com/sowhat/presentation/common/TextFieldInfo.kt
@@ -1,2 +1,10 @@
 package com.sowhat.presentation.common
 
+import androidx.constraintlayout.helper.widget.MotionPlaceholder
+
+data class TextFieldInfo(
+    val title: String,
+    val value: String,
+    val placeholder: String,
+    val onValueChange: (String) -> Unit
+)

--- a/authentication/authentication-presentation/src/main/java/com/sowhat/presentation/common/TextFieldInfo.kt
+++ b/authentication/authentication-presentation/src/main/java/com/sowhat/presentation/common/TextFieldInfo.kt
@@ -1,0 +1,2 @@
+package com.sowhat.presentation.common
+

--- a/authentication/authentication-presentation/src/main/java/com/sowhat/presentation/component/Input.kt
+++ b/authentication/authentication-presentation/src/main/java/com/sowhat/presentation/component/Input.kt
@@ -1,0 +1,2 @@
+package com.sowhat.presentation.component
+

--- a/authentication/authentication-presentation/src/main/java/com/sowhat/presentation/component/Input.kt
+++ b/authentication/authentication-presentation/src/main/java/com/sowhat/presentation/component/Input.kt
@@ -1,2 +1,46 @@
 package com.sowhat.presentation.component
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.sowhat.designsystem.component.DefaultHeader
+import com.sowhat.designsystem.component.OutlinedDefaultTextField
+import com.sowhat.designsystem.theme.JustSayItTheme
+import com.sowhat.presentation.common.TextFieldInfo
+
+@Composable
+fun DobTextField(
+    modifier: Modifier = Modifier,
+    title: String,
+    items: List<TextFieldInfo>
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(JustSayItTheme.Spacing.spaceMedium),
+        verticalArrangement = Arrangement.spacedBy(JustSayItTheme.Spacing.spaceNormal)
+    ) {
+        DefaultHeader(title = title)
+
+        Row(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            items.forEachIndexed { index, item ->
+                if (index != 0) Spacer(modifier = Modifier.width(JustSayItTheme.Spacing.spaceExtraSmall))
+
+                OutlinedDefaultTextField(
+                    modifier = Modifier.weight(1f),
+                    placeholder = item.placeholder,
+                    value = item.value,
+                    onValueChange = item.onValueChange
+                )
+            }
+        }
+    }
+}

--- a/authentication/authentication-presentation/src/main/java/com/sowhat/presentation/component/Selection.kt
+++ b/authentication/authentication-presentation/src/main/java/com/sowhat/presentation/component/Selection.kt
@@ -1,0 +1,58 @@
+package com.sowhat.presentation.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.sowhat.designsystem.component.DefaultButtonDual
+import com.sowhat.designsystem.component.DefaultHeader
+import com.sowhat.designsystem.theme.JustSayItTheme
+
+@Composable
+fun Selection(
+    modifier: Modifier = Modifier,
+    title: String,
+    buttons: List<String>,
+    activeButton: String?,
+    onClick: (String) -> Unit
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(JustSayItTheme.Spacing.spaceMedium),
+        verticalArrangement = Arrangement.spacedBy(JustSayItTheme.Spacing.spaceNormal)
+    ) {
+        DefaultHeader(title = title)
+
+        DefaultButtonDual(
+            buttons = buttons,
+            activeButton = activeButton,
+            onClick = onClick
+        )
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xffffffff)
+@Composable
+fun SelectionPreview() {
+
+    val items = listOf("남", "여")
+
+    var selectedItem by remember {
+        mutableStateOf(items.first())
+    }
+
+    Selection(
+        title = "성별",
+        buttons = items,
+        activeButton = selectedItem,
+        onClick = { selected -> selectedItem = selected }
+    )
+}

--- a/authentication/authentication-presentation/src/main/java/com/sowhat/presentation/configuration/UserConfigScreen.kt
+++ b/authentication/authentication-presentation/src/main/java/com/sowhat/presentation/configuration/UserConfigScreen.kt
@@ -5,8 +5,10 @@ import android.view.ViewTreeObserver
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
+import androidx.compose.foundation.basicMarquee
 import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -147,7 +149,9 @@ fun UserConfigRoute(
     )
 }
 
-@OptIn(ExperimentalLayoutApi::class, ExperimentalComposeUiApi::class)
+@OptIn(ExperimentalLayoutApi::class, ExperimentalComposeUiApi::class,
+    ExperimentalFoundationApi::class
+)
 @Composable
 fun UserConfigScreen(
     modifier: Modifier = Modifier,
@@ -181,9 +185,11 @@ fun UserConfigScreen(
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Text(
+                    modifier = Modifier.basicMarquee(),
                     text = stringResource(id = R.string.desc_info_immutable),
                     style = JustSayItTheme.Typography.detail1,
-                    color = Gray500
+                    color = Gray500,
+                    maxLines = 1
                 )
 
                 DefaultButtonFull(
@@ -244,7 +250,7 @@ fun UserConfigScreen(
                 modifier = Modifier
                     .fillMaxWidth(),
                 title = stringResource(id = R.string.title_dob),
-                items = dobItems
+                items = dobItems,
             )
         }
     }

--- a/authentication/authentication-presentation/src/main/java/com/sowhat/presentation/configuration/UserConfigViewModel.kt
+++ b/authentication/authentication-presentation/src/main/java/com/sowhat/presentation/configuration/UserConfigViewModel.kt
@@ -17,4 +17,5 @@ class UserConfigViewModel @Inject constructor() : ViewModel() {
     val isValid by derivedStateOf {
         id.length in (2..12) && hasImage && imageUri != null
     }
+
 }

--- a/authentication/authentication-presentation/src/main/java/com/sowhat/presentation/onboarding/OnboardingScreen.kt
+++ b/authentication/authentication-presentation/src/main/java/com/sowhat/presentation/onboarding/OnboardingScreen.kt
@@ -6,6 +6,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
@@ -113,7 +114,7 @@ fun OnboardingScreen(
     )
 
     ConstraintLayout(
-        modifier = modifier.fillMaxSize()
+        modifier = modifier.fillMaxSize().background(JustSayItTheme.Colors.mainBackground)
     ) {
         val (logo, signIn, terms) = createRefs()
         val topSpace = JustSayItTheme.Spacing.spaceExtraExtraLarge

--- a/core/common/src/main/java/com/sowhat/common/util/ImeState.kt
+++ b/core/common/src/main/java/com/sowhat/common/util/ImeState.kt
@@ -1,0 +1,2 @@
+package com.sowhat.common.util
+

--- a/core/common/src/main/java/com/sowhat/common/util/KeyboardController.kt
+++ b/core/common/src/main/java/com/sowhat/common/util/KeyboardController.kt
@@ -1,0 +1,1 @@
+package com.sowhat.common.util

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/common/Constants.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/common/Constants.kt
@@ -6,10 +6,12 @@ const val APP_INTRO = "(서비스 한줄 소개)"
 const val SIGN_IN = "간편 로그인"
 const val COMPLETE = "완료"
 
-const val CONFIG_ID_TITLE = "아이디"
-const val CONFIG_ID_PLACEHOLDER = "2자 이상 12자 이하"
+const val CONFIG_NICKNAME_TITLE = "닉네임"
+const val CONFIG_NICKNAME_PLACEHOLDER = "2자 이상 12자 이하"
 
-const val PLATFORM_NAVER = "naver"
+const val PLATFORM_NAVER = "NAVER"
+const val PLATFORM_GOOGLE = "GOOGLE"
+const val PLATFORM_KAKAO = "KAKAO"
 
 const val APPBAR_SETTING = "설정"
 const val PROFILE_SETTING = "프로필 설정"

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/common/DropdownItem.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/common/DropdownItem.kt
@@ -3,4 +3,5 @@ package com.sowhat.designsystem.common
 data class DropdownItem(
     val title: String,
     val drawable: Int? = null,
+    val onItemClick: (() -> Unit)? = null
 )

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/common/RippleEffect.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/common/RippleEffect.kt
@@ -19,3 +19,15 @@ fun Modifier.rippleClickable(
         onClick = onClick
     )
 }
+
+fun Modifier.noRippleClickable(
+    onClick: () -> Unit
+): Modifier = composed {
+    clickable (
+        interactionSource = remember {
+            MutableInteractionSource()
+        },
+        indication = null,
+        onClick = onClick
+    )
+}

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/component/Button.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/component/Button.kt
@@ -170,7 +170,7 @@ fun DefaultButtonDual(
 fun DefaultButtonDual(
     modifier: Modifier = Modifier,
     buttons: List<String>,
-    activeButton: String,
+    activeButton: String?,
     textStyle: TextStyle = JustSayItTheme.Typography.body1,
     onClick: (String) -> Unit
 ) {

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/component/Cell.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/component/Cell.kt
@@ -87,7 +87,8 @@ fun Cell(
             .padding(
                 horizontal = 16.dp,
                 vertical = 4.dp
-            ),
+            )
+            .fillMaxWidth(),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
     ) {

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/component/Chip.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/component/Chip.kt
@@ -1,6 +1,7 @@
 package com.sowhat.designsystem.component
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -11,6 +12,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -22,29 +27,35 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.sowhat.designsystem.R
 import com.sowhat.designsystem.common.rippleClickable
+import com.sowhat.designsystem.theme.Black
 import com.sowhat.designsystem.theme.Gray300
+import com.sowhat.designsystem.theme.Gray900
 import com.sowhat.designsystem.theme.JustSayItTheme
+import com.sowhat.designsystem.theme.White
 
 @Composable
 fun Chip(
+    isSelected: Boolean,
     modifier: Modifier = Modifier,
     drawableStart: Int?,
     drawableSize: Dp,
     textStyle: TextStyle,
+    backgroundColor: Color,
     title: String,
     textColor: Color,
-    onClick: (String) -> Unit
+    onClick: (String, Boolean) -> Unit
 ) {
     Box(
         modifier = modifier
             .clip(RoundedCornerShape(percent = 50))
+            .background(color = backgroundColor)
             .border(
                 width = 1.dp,
                 color = Gray300,
                 shape = RoundedCornerShape(50)
             )
             .rippleClickable {
-                onClick(title)
+                onClick(title, !isSelected)
             }
     ) {
         Row(
@@ -77,58 +88,78 @@ fun Chip(
 
 @Composable
 fun ChipMedium(
+    isSelected: Boolean,
     modifier: Modifier = Modifier,
     drawableStart: Int?,
     title: String,
     textColor: Color = JustSayItTheme.Colors.mainTypo,
-    onClick: (String) -> Unit
+    backgroundColor: Color = JustSayItTheme.Colors.mainBackground,
+    onClick: (String, Boolean) -> Unit
 ) {
     Chip(
+        isSelected = isSelected,
         modifier = modifier,
         drawableStart = drawableStart,
         drawableSize = 24.dp,
         textStyle = JustSayItTheme.Typography.body1,
         title = title,
         onClick = onClick,
-        textColor = textColor
+        textColor = textColor,
+        backgroundColor = backgroundColor
     )
 }
 
 @Composable
 fun ChipSmall(
+    isSelected: Boolean,
     modifier: Modifier = Modifier,
     drawableStart: Int?,
     title: String,
     textColor: Color = JustSayItTheme.Colors.mainTypo,
-    onClick: (String) -> Unit
+    backgroundColor: Color = JustSayItTheme.Colors.mainBackground,
+    onClick: (String, Boolean) -> Unit
 ) {
     Chip(
+        isSelected = isSelected,
         modifier = modifier,
         drawableStart = drawableStart,
         drawableSize = JustSayItTheme.Spacing.spaceLarge,
         textStyle = JustSayItTheme.Typography.detail1,
         title = title,
         onClick = onClick,
-        textColor = textColor
+        textColor = textColor,
+        backgroundColor = backgroundColor
     )
 }
 
 @Preview(showBackground = true, backgroundColor = 0xffffffff)
 @Composable
 fun ChipPreview() {
+    
+    var isSelected by remember {
+        mutableStateOf(true)
+    }
+
+    val textColor = if (isSelected) White else Gray900
+    val backgroundColor = if (isSelected) Black else White
+    
     Column {
         ChipMedium(
+            isSelected = isSelected,
             drawableStart = R.drawable.ic_happy_24,
             title = "행복",
-            textColor = JustSayItTheme.Colors.mainTypo,
-            onClick = {}
+            textColor = textColor,
+            onClick = { _, changedState -> isSelected = changedState },
+            backgroundColor = backgroundColor
         )
 
         ChipSmall(
+            isSelected = isSelected,
             drawableStart = R.drawable.ic_happy_24,
             title = "행복",
-            textColor = JustSayItTheme.Colors.mainTypo,
-            onClick = {}
+            textColor = textColor,
+            backgroundColor = backgroundColor,
+            onClick = { _, changedState -> isSelected = changedState }
         )
     }
 }

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/component/Header.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/component/Header.kt
@@ -33,6 +33,17 @@ fun Header(
     }
 }
 
+@Composable
+fun DefaultHeader(title: String) {
+    Text(
+        text = title,
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+        style = JustSayItTheme.Typography.body1,
+        color = JustSayItTheme.Colors.mainTypo
+    )
+}
+
 @Preview(showBackground = true, backgroundColor = 0xffffffff)
 @Composable
 fun HeaderPreview() {

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/component/Image.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/component/Image.kt
@@ -61,6 +61,30 @@ fun ImageContainer(
 }
 
 @Composable
+fun ImageContainer(
+    modifier: Modifier = Modifier,
+    borderWidth: Dp,
+    borderColor: Color,
+    shape: CornerBasedShape,
+    model: Any?,
+    contentDescription : String?
+) {
+    Box(
+        modifier = modifier
+            .border(width = borderWidth, color = borderColor, shape = shape)
+            .clip(shape)
+
+    ) {
+        AsyncImage(
+            modifier = Modifier.fillMaxSize(),
+            model = model,
+            contentDescription = contentDescription,
+            contentScale = ContentScale.Crop
+        )
+    }
+}
+
+@Composable
 fun ProfileImageContainer(
     modifier: Modifier = Modifier,
     model: Any?,
@@ -68,7 +92,7 @@ fun ProfileImageContainer(
 ) {
     ImageContainer(
         modifier = modifier.aspectRatio(1f),
-        borderWidth = 2.dp,
+        borderWidth = 0.5.dp,
         borderColor = JustSayItTheme.Colors.subSurface,
         shape = JustSayItTheme.Shapes.large,
         model = model,

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/component/ProfileImage.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/component/ProfileImage.kt
@@ -135,6 +135,6 @@ fun ProfileImagePreview() {
         badgeDrawable = R.drawable.ic_camera_24,
         badgeBackgroundColor = Gray200,
         badgeIconTint = Gray400,
-        onClick = {}
+        onClick = {},
     )
 }

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/component/ProfileImage.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/component/ProfileImage.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -116,7 +117,7 @@ fun ProfileImage(
             )
 
             DropdownContents(
-                modifier = Modifier,
+                modifier = Modifier.width(136.dp),
                 isVisible = dropdownVisible,
                 items = dropdownMenuItems,
                 onDismiss = onDropdownDismiss,

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/component/TextField.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/component/TextField.kt
@@ -1,17 +1,19 @@
 package com.sowhat.designsystem.component
 
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -20,10 +22,10 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.sowhat.designsystem.common.bottomBorder
@@ -47,10 +49,27 @@ fun DefaultTextField(
             ),
         verticalArrangement = Arrangement.spacedBy(JustSayItTheme.Spacing.spaceExtraSmall)
     ) {
-        DefaultTextFieldTitle(title)
+        DefaultHeader(title)
         DefaultTextFieldContent(value, onValueChange, placeholder)
     }
 }
+
+//@Composable
+//fun OutlinedTextFieldDefault(
+//    modifier: Modifier = Modifier,
+//    placeholder: String,
+//    value: String,
+//    onValueChange: (String) -> Unit,
+//) {
+//    Box(
+//        modifier = modifier
+//            .fillMaxWidth()
+//            .height(44.dp)
+//            .clip(JustSayItTheme.Shapes.medium)
+//            .border(width = 1.dp, ),
+//
+//    )
+//}
 
 @Composable
 fun OutlinedDefaultTextField(
@@ -58,16 +77,17 @@ fun OutlinedDefaultTextField(
     placeholder: String,
     value: String,
     onValueChange: (String) -> Unit,
-    isValid: Boolean,
 ) {
     OutlinedTextField(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth(),
         value = value,
         onValueChange = onValueChange,
         singleLine = true,
         placeholder = {
             Text(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth(),
                 text = placeholder,
                 textAlign = TextAlign.Center
             )
@@ -125,16 +145,6 @@ private fun DefaultTextFieldContent(
 }
 
 @Composable
-private fun DefaultTextFieldTitle(title: String) {
-    Text(
-        text = title,
-        maxLines = 1,
-        overflow = TextOverflow.Ellipsis,
-        style = JustSayItTheme.Typography.body1
-    )
-}
-
-@Composable
 private fun PlaceholderText(value: String, placeholder: String) {
     Row(
         modifier = Modifier
@@ -177,6 +187,5 @@ fun OutlinedTextFieldPreview() {
         placeholder = "YYYY",
         value = text,
         onValueChange = { text = it },
-        isValid = text.length == 4,
     )
 }

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/component/TextField.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/component/TextField.kt
@@ -89,7 +89,9 @@ fun OutlinedDefaultTextField(
                 modifier = Modifier
                     .fillMaxWidth(),
                 text = placeholder,
-                textAlign = TextAlign.Center
+                textAlign = TextAlign.Center,
+                style = JustSayItTheme.Typography.body1,
+                color = Gray500
             )
         },
         textStyle = JustSayItTheme.Typography.body1.copy(textAlign = TextAlign.Center),

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/component/TextField.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/component/TextField.kt
@@ -8,15 +8,21 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -44,6 +50,45 @@ fun DefaultTextField(
         DefaultTextFieldTitle(title)
         DefaultTextFieldContent(value, onValueChange, placeholder)
     }
+}
+
+@Composable
+fun OutlinedDefaultTextField(
+    modifier: Modifier = Modifier,
+    placeholder: String,
+    value: String,
+    onValueChange: (String) -> Unit,
+    isValid: Boolean,
+) {
+    OutlinedTextField(
+        modifier = modifier.fillMaxWidth(),
+        value = value,
+        onValueChange = onValueChange,
+        singleLine = true,
+        placeholder = {
+            Text(
+                modifier = Modifier.fillMaxWidth(),
+                text = placeholder,
+                textAlign = TextAlign.Center
+            )
+        },
+        textStyle = JustSayItTheme.Typography.body1.copy(textAlign = TextAlign.Center),
+        maxLines = 1,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+        shape = JustSayItTheme.Shapes.medium,
+        colors = OutlinedTextFieldDefaults.colors(
+            focusedTextColor = JustSayItTheme.Colors.mainTypo,
+            unfocusedTextColor = JustSayItTheme.Colors.mainTypo,
+            focusedPlaceholderColor = Gray500,
+            unfocusedPlaceholderColor = Gray500,
+            focusedContainerColor = JustSayItTheme.Colors.mainSurface,
+            unfocusedContainerColor = JustSayItTheme.Colors.mainSurface,
+            cursorColor = Color.Transparent,
+            errorCursorColor = Color.Transparent,
+            focusedBorderColor = JustSayItTheme.Colors.mainTypo,
+            unfocusedBorderColor = Gray500
+        )
+    )
 }
 
 @Composable
@@ -118,4 +163,20 @@ fun TextFieldPreview() {
         placeholder = "2자 이상 12자 이하"
     )
 
+}
+
+@Preview(showBackground = true)
+@Composable
+fun OutlinedTextFieldPreview() {
+
+    var text by remember {
+        mutableStateOf("")
+    }
+
+    OutlinedDefaultTextField(
+        placeholder = "YYYY",
+        value = text,
+        onValueChange = { text = it },
+        isValid = text.length == 4,
+    )
 }

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/component/Toggle.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/component/Toggle.kt
@@ -1,0 +1,49 @@
+package com.sowhat.designsystem.component
+
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.tooling.preview.Preview
+import com.sowhat.designsystem.theme.JustSayItTheme
+import com.sowhat.designsystem.theme.White
+
+@Composable
+fun Toggle(
+    modifier: Modifier = Modifier,
+    isChecked: Boolean,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    Switch(
+        modifier = modifier,
+        checked = isChecked,
+        onCheckedChange = onCheckedChange,
+        colors = SwitchDefaults.colors(
+            checkedThumbColor = White,
+            uncheckedThumbColor = White,
+            checkedTrackColor = JustSayItTheme.Colors.mainTypo,
+            uncheckedTrackColor = JustSayItTheme.Colors.subBackground,
+            checkedBorderColor = JustSayItTheme.Colors.mainTypo,
+            uncheckedBorderColor = JustSayItTheme.Colors.subBackground,
+        ),
+        thumbContent = {
+            // 공백으로 두어야 thumb가 track에 꽉 차게 된다.
+        }
+    )
+}
+
+@Preview(showBackground = true, backgroundColor = 0xffffffff)
+@Composable
+fun TogglePreview() {
+    var isChecked by remember {
+        mutableStateOf(false)
+    }
+    Toggle(isChecked = isChecked, onCheckedChange = { newState -> isChecked = newState })
+}

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/theme/Theme.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/theme/Theme.kt
@@ -47,7 +47,7 @@ object JustSayItTheme {
 val LightColorScheme = JustSayItColor(
     mainTypo = Gray900,
     subTypo = Gray700,
-    mainBackground = Gray100,
+    mainBackground = White,
     subBackground = Gray200,
     mainSurface = White,
     onMainSurface = NavIconLight,
@@ -61,7 +61,7 @@ val LightColorScheme = JustSayItColor(
 val DarkColorScheme = JustSayItColor(
     mainTypo = Gray900,
     subTypo = Gray700,
-    mainBackground = Gray100,
+    mainBackground = White,
     subBackground = Gray200,
     mainSurface = White,
     onMainSurface = NavIconLight,

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/theme/Type.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/theme/Type.kt
@@ -55,6 +55,7 @@ private val Heading1 = TextStyle(
         includeFontPadding = false
     ),
     lineHeight = 34.sp,
+    letterSpacing = (-0.06).sp,
 //    lineHeight = TextUnit(value = 1.4f, type = TextUnitType.Em),
 //    letterSpacing = TextUnit(value = 0.75f, type = TextUnitType.Em),
     color = Gray900
@@ -68,6 +69,7 @@ private val Heading2 = TextStyle(
         includeFontPadding = false
     ),
     lineHeight = 32.sp,
+    letterSpacing = (-0.055).sp,
 //    lineHeight = TextUnit(value = 1.45f, type = TextUnitType.Em),
 //    letterSpacing = TextUnit(value = 0.75f, type = TextUnitType.Em),
     color = Gray900
@@ -81,6 +83,7 @@ private val Heading3 = TextStyle(
         includeFontPadding = false
     ),
     lineHeight = 28.sp,
+    letterSpacing = (-0.05).sp,
 //    lineHeight = TextUnit(value = 1.4f, type = TextUnitType.Em),
 //    letterSpacing = TextUnit(value = 0.75f, type = TextUnitType.Em),
     color = Gray900
@@ -94,6 +97,7 @@ private val Heading4 = TextStyle(
         includeFontPadding = false
     ),
     lineHeight = 26.sp,
+    letterSpacing = (-0.045).sp,
 //    lineHeight = TextUnit(value = 1.45f, type = TextUnitType.Em),
 //    letterSpacing = TextUnit(value = 0.75f, type = TextUnitType.Em),
     color = Gray900
@@ -107,6 +111,7 @@ private val Body1 = TextStyle(
         includeFontPadding = false
     ),
     lineHeight = 22.sp,
+    letterSpacing = (-0.04).sp,
 //    lineHeight = TextUnit(value = 1.4f, type = TextUnitType.Em),
 //    letterSpacing = TextUnit(value = 0.75f, type = TextUnitType.Em),
 )
@@ -119,6 +124,7 @@ private val Body2 = TextStyle(
         includeFontPadding = false
     ),
     lineHeight = 22.sp,
+    letterSpacing = (-0.04).sp,
 //    lineHeight = TextUnit(value = 1.4f, type = TextUnitType.Em),
 //    letterSpacing = TextUnit(value = 0.75f, type = TextUnitType.Em),
     color = Gray900
@@ -132,6 +138,7 @@ private val Body3 = TextStyle(
         includeFontPadding = false
     ),
     lineHeight = 20.sp,
+    letterSpacing = (-0.028).sp,
 //    lineHeight = TextUnit(value = 1.4f, type = TextUnitType.Em),
 //    letterSpacing = TextUnit(value = 0.8f, type = TextUnitType.Em),
     color = Gray900
@@ -145,6 +152,7 @@ private val Body4 = TextStyle(
         includeFontPadding = false
     ),
     lineHeight = 20.sp,
+    letterSpacing = (-0.028).sp,
 //    lineHeight = TextUnit(value = 1.4f, type = TextUnitType.Em),
 //    letterSpacing = TextUnit(value = 0.8f, type = TextUnitType.Em),
     color = Gray900
@@ -158,6 +166,7 @@ private val Detail1 = TextStyle(
         includeFontPadding = false
     ),
     lineHeight = 18.sp,
+    letterSpacing = (-0.024).sp,
     color = Gray900
 )
 
@@ -170,6 +179,7 @@ private val Detail2 = TextStyle(
     ),
 //    lineHeight = TextUnit(value = 1.4f, type = TextUnitType.Em),
     lineHeight = 18.sp,
+    letterSpacing = (-0.024).sp,
     color = Gray900
 )
 

--- a/core/designsystem/src/main/res/values/string.xml
+++ b/core/designsystem/src/main/res/values/string.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="title_nickname">닉네임</string>
+    <string name="title_gender">성별</string>
+    <string name="title_dob">생년월일</string>
+
+    <string name="desc_info_immutable">성별과 생년월일은 추후 변경이 불가합니다. 정확히 입력해주세요</string>
+
+    <string name="placeholder_nickname">2자 이상 12자 이하</string>
+    <string name="item_gender_male">남</string>
+    <string name="item_gender_female">여</string>
+    <string name="placeholder_dob_year">YYYY</string>
+    <string name="placeholder_dob_month">MM</string>
+    <string name="placeholder_dob_day">DD</string>
+
+    <string name="button_start">시작하기</string>
+</resources>

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/edit/EditScreen.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/edit/EditScreen.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.sowhat.designsystem.R
 import com.sowhat.designsystem.common.COMPLETE
-import com.sowhat.designsystem.common.CONFIG_ID_TITLE
+import com.sowhat.designsystem.common.CONFIG_NICKNAME_TITLE
 import com.sowhat.designsystem.common.DropdownItem
 import com.sowhat.designsystem.common.PROFILE_SETTING
 import com.sowhat.designsystem.component.AppBar
@@ -143,12 +143,15 @@ fun EditScreenContent(
             onClick = onProfileClick,
             dropdownVisible = dropdownVisible,
             dropdownMenuItems = dropdownMenuItems,
-            onDropdownDismiss = onDropdownDismiss
+            onDropdownDismiss = onDropdownDismiss,
+            onItemClick = { dropdownItem ->
+
+            }
         )
 
         DefaultTextField(
             modifier = Modifier,
-            title = CONFIG_ID_TITLE,
+            title = CONFIG_NICKNAME_TITLE,
             placeholder = userName,
             value = newUserName,
             onValueChange = onUserNameChange

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/edit/EditScreen.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/edit/EditScreen.kt
@@ -3,8 +3,10 @@ package com.sowhat.user_presentation.edit
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
@@ -14,6 +16,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.sowhat.designsystem.R
@@ -22,10 +25,12 @@ import com.sowhat.designsystem.common.CONFIG_NICKNAME_TITLE
 import com.sowhat.designsystem.common.DropdownItem
 import com.sowhat.designsystem.common.PROFILE_SETTING
 import com.sowhat.designsystem.component.AppBar
+import com.sowhat.designsystem.component.Cell
 import com.sowhat.designsystem.component.DefaultTextField
 import com.sowhat.designsystem.component.ProfileImage
 import com.sowhat.designsystem.theme.Gray200
 import com.sowhat.designsystem.theme.Gray400
+import com.sowhat.designsystem.theme.JustSayItTheme
 
 @Composable
 fun EditRoute(
@@ -113,7 +118,9 @@ fun EditScreen(
             newUserName = newUserName,
             dropdownVisible = dropdownVisible,
             dropdownMenuItems = dropdownMenuItems,
-            onDropdownDismiss = onDropdownDismiss
+            onDropdownDismiss = onDropdownDismiss,
+            gender = "남",
+            dob = "1998.11.23"
         )
     }
 }
@@ -129,10 +136,14 @@ fun EditScreenContent(
     onUserNameChange: (String) -> Unit,
     dropdownVisible: Boolean,
     dropdownMenuItems: List<DropdownItem>,
-    onDropdownDismiss: () -> Unit
+    onDropdownDismiss: () -> Unit,
+    gender: String,
+    dob: String
 ) {
     Column(
-        modifier = modifier.fillMaxSize()
+        modifier = modifier
+            .fillMaxSize()
+            .background(JustSayItTheme.Colors.mainBackground)
     ) {
         ProfileImage(
             modifier = Modifier,
@@ -156,6 +167,10 @@ fun EditScreenContent(
             value = newUserName,
             onValueChange = onUserNameChange
         )
+
+        Cell(title = stringResource(id = R.string.title_gender), leadingIcon = null, trailingText = gender)
+
+        Cell(title = stringResource(id = R.string.title_dob), leadingIcon = null, trailingText = dob)
     }
 }
 

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/edit/EditScreen.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/edit/EditScreen.kt
@@ -15,7 +15,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -24,6 +26,7 @@ import com.sowhat.designsystem.common.COMPLETE
 import com.sowhat.designsystem.common.CONFIG_NICKNAME_TITLE
 import com.sowhat.designsystem.common.DropdownItem
 import com.sowhat.designsystem.common.PROFILE_SETTING
+import com.sowhat.designsystem.common.noRippleClickable
 import com.sowhat.designsystem.component.AppBar
 import com.sowhat.designsystem.component.Cell
 import com.sowhat.designsystem.component.DefaultTextField
@@ -125,6 +128,7 @@ fun EditScreen(
     }
 }
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun EditScreenContent(
     modifier: Modifier = Modifier,
@@ -140,10 +144,13 @@ fun EditScreenContent(
     gender: String,
     dob: String
 ) {
+    val keyboardController = LocalSoftwareKeyboardController.current
+
     Column(
         modifier = modifier
             .fillMaxSize()
             .background(JustSayItTheme.Colors.mainBackground)
+            .noRippleClickable { keyboardController?.hide() }
     ) {
         ProfileImage(
             modifier = Modifier,

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/setting/SettingScreen.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/setting/SettingScreen.kt
@@ -1,5 +1,6 @@
 package com.sowhat.user_presentation.setting
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -59,6 +60,7 @@ private fun SettingScreenContent(
     Column(
         modifier = modifier
             .fillMaxSize()
+            .background(JustSayItTheme.Colors.mainBackground)
     ) {
         ProfileSection()
 


### PR DESCRIPTION
* 디자인 변경에 따른 컴포넌트 추가, 수정 및 레이아웃 반영
  * 성별, 생년월일 정보를 입력받기 위한 컴포넌트
  * 칩 : 감정을 나타내기 위한 버튼 컴포넌트
  * 버튼 : active 여부에 따라 배경과 텍스트 색상이 변경되는 컴포넌트
  * 토글 : on/off 스위치
  * 레이아웃 수정 과정에서, 키보드로 입력 중 화면의 다른 영역 터치 시 키보드 collapse되도록 구현
    * LocalSoftwareKeyboardController 활용
  * 회원정보 최초 입력 화면에서 수정 불가능 문구 추가, 기존의 앱바에 있던 완료 버튼을 하단으로 재배치
  * 회원 정보 수정 화면에서 성별과 생일 셀 추가