### PR TITLE
✨💄 Feat: implement sign out layout and server connection

### DIFF
--- a/app/src/main/java/com/sowhat/justsayit/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/sowhat/justsayit/navigation/AppNavHost.kt
@@ -9,6 +9,7 @@ import com.sowhat.main_presentation.navigation.mainScreen
 import com.sowhat.authentication_presentation.navigation.onBoardingScreen
 import com.sowhat.authentication_presentation.navigation.userConfigScreen
 import com.sowhat.post_presentation.navigation.postScreen
+import com.sowhat.user_presentation.navigation.signOutScreen
 import com.sowhat.user_presentation.navigation.userInfoUpdateScreen
 
 @Composable
@@ -23,5 +24,6 @@ fun AppNavHost(
         mainScreen(appNavController = navController)
         postScreen(appNavController = navController)
         userInfoUpdateScreen(appNavController = navController)
+        signOutScreen(appNavController = navController)
     }
 }

--- a/authentication/authentication-data/src/main/java/com/sowhat/authentication_data/model/response/SignInResult.kt
+++ b/authentication/authentication-data/src/main/java/com/sowhat/authentication_data/model/response/SignInResult.kt
@@ -11,5 +11,5 @@ data class SignInResult(
     @SerialName("isJoined")
     val isJoined: Boolean,
     @SerialName("memberId")
-    val memberId: Int?
+    val memberId: Long?
 )

--- a/authentication/authentication-domain/src/main/java/com/sowhat/authentication_domain/model/SignIn.kt
+++ b/authentication/authentication-domain/src/main/java/com/sowhat/authentication_domain/model/SignIn.kt
@@ -11,5 +11,5 @@ data class SignIn(
     @SerialName("isJoined")
     val isJoined: Boolean,
     @SerialName("memberId")
-    val memberId: Int?
+    val memberId: Long?
 )

--- a/authentication/authentication-presentation/src/main/java/com/sowhat/authentication_presentation/configuration/UserConfigScreen.kt
+++ b/authentication/authentication-presentation/src/main/java/com/sowhat/authentication_presentation/configuration/UserConfigScreen.kt
@@ -67,6 +67,7 @@ import com.sowhat.authentication_presentation.component.DescButton
 import com.sowhat.authentication_presentation.component.DobTextField
 import com.sowhat.authentication_presentation.component.Selection
 import com.sowhat.authentication_presentation.navigation.navigateToMain
+import com.sowhat.common.navigation.CONFIG_EDIT
 
 @Composable
 fun UserConfigRoute(
@@ -90,7 +91,7 @@ fun UserConfigRoute(
         when (uiEvent) {
             is SignUpEvent.NavigateToMain -> {
                 Log.i(USER_CONFIG_SCREEN, "navigate to main")
-                navController.navigateToMain()
+                navController.navigateToMain(popUpTo = CONFIG_EDIT)
             }
             is SignUpEvent.Error -> {
                 Log.i(USER_CONFIG_SCREEN, "error ${uiEvent.message}")

--- a/authentication/authentication-presentation/src/main/java/com/sowhat/authentication_presentation/navigation/AuthNavigation.kt
+++ b/authentication/authentication-presentation/src/main/java/com/sowhat/authentication_presentation/navigation/AuthNavigation.kt
@@ -36,6 +36,11 @@ fun NavGraphBuilder.userConfigScreen(
     }
 }
 
-fun NavController.navigateToMain(navOptions: NavOptions? = null) {
-    this.navigate(MAIN, navOptions)
+fun NavController.navigateToMain(popUpTo: String) {
+    this.navigate(MAIN) {
+        popUpTo(popUpTo) {
+            inclusive = true
+        }
+        launchSingleTop = true
+    }
 }

--- a/authentication/authentication-presentation/src/main/java/com/sowhat/authentication_presentation/onboarding/OnboardingScreen.kt
+++ b/authentication/authentication-presentation/src/main/java/com/sowhat/authentication_presentation/onboarding/OnboardingScreen.kt
@@ -38,6 +38,7 @@ import com.sowhat.authentication_presentation.navigation.navigateToUserConfig
 import com.sowhat.authentication_presentation.util.GoogleOAuthClient
 import com.sowhat.authentication_presentation.util.KakaoOAuthClient
 import com.sowhat.authentication_presentation.util.NaverOAuthClient
+import com.sowhat.common.navigation.ONBOARDING
 import kotlinx.coroutines.launch
 
 @Composable
@@ -52,7 +53,7 @@ fun OnboardingRoute(
         when (uiEvent) {
             is SignInEvent.NavigateToMain -> {
                 Log.i("OnboardingScreen", "navigate to main")
-                navController.navigateToMain()
+                navController.navigateToMain(popUpTo = ONBOARDING)
             }
             is SignInEvent.NavigateToSignUp -> {
                 Log.i("OnboardingScreen", "navigate to user config")

--- a/authentication/authentication-presentation/src/main/java/com/sowhat/authentication_presentation/onboarding/OnboardingViewModel.kt
+++ b/authentication/authentication-presentation/src/main/java/com/sowhat/authentication_presentation/onboarding/OnboardingViewModel.kt
@@ -1,5 +1,6 @@
 package com.sowhat.authentication_presentation.onboarding
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.sowhat.authentication_domain.model.SignIn
@@ -44,16 +45,18 @@ class OnboardingViewModel @Inject constructor(
         _uiState.value = _uiState.value.copy(isLoading = true)
 
         val accessToken = tokens.await().accessToken
+        Log.i("OnboardingScreen", "access token : $accessToken")
 
         if (accessToken.isNullOrBlank()) {
+            Log.i("OnboardingScreen", "access token is null : $accessToken")
             authDataStore.apply {
                 updatePlatform(platform = platform.title)
                 updatePlatformToken(platformToken = derivedPlatformToken)
             }
         }
 
-        // 만약 액세스 토큰이 없을 때 갱신되었을 수 있기 때문에 여기에 선언
-        val platformToken = tokens.await().platformToken
+        // 만약 액세스 토큰이 없을 때 갱신되었을 수 있기 때문에 여기에 새로 선언
+        val platformToken = authDataStore.authData.first().platformToken
         val signInData = signInUseCase(platformToken)
 
         consumeResources(signInData)

--- a/authentication/authentication-presentation/src/main/java/com/sowhat/authentication_presentation/onboarding/OnboardingViewModel.kt
+++ b/authentication/authentication-presentation/src/main/java/com/sowhat/authentication_presentation/onboarding/OnboardingViewModel.kt
@@ -44,11 +44,11 @@ class OnboardingViewModel @Inject constructor(
     ) = viewModelScope.launch {
         _uiState.value = _uiState.value.copy(isLoading = true)
 
-        val accessToken = tokens.await().accessToken
-        Log.i("OnboardingScreen", "access token : $accessToken")
+        val platformToken = tokens.await().platformToken
+        Log.i("OnboardingScreen", "platformToken : $platformToken")
 
-        if (accessToken.isNullOrBlank()) {
-            Log.i("OnboardingScreen", "access token is null : $accessToken")
+        if (platformToken.isNullOrBlank()) {
+            Log.i("OnboardingScreen", "platformToken is null : $platformToken")
             authDataStore.apply {
                 updatePlatform(platform = platform.title)
                 updatePlatformToken(platformToken = derivedPlatformToken)
@@ -56,8 +56,8 @@ class OnboardingViewModel @Inject constructor(
         }
 
         // 만약 액세스 토큰이 없을 때 갱신되었을 수 있기 때문에 여기에 새로 선언
-        val platformToken = authDataStore.authData.first().platformToken
-        val signInData = signInUseCase(platformToken)
+        val newPlatformToken = authDataStore.authData.first().platformToken
+        val signInData = signInUseCase(newPlatformToken)
 
         consumeResources(signInData)
     }

--- a/core/common/src/main/java/com/sowhat/common/model/UiEvents.kt
+++ b/core/common/src/main/java/com/sowhat/common/model/UiEvents.kt
@@ -55,9 +55,3 @@ sealed class SignOutEvent {
     data class SignOutVisibilityChanged(val isVisible: Boolean) : SignOutEvent()
     data class WithdrawVisibilityChanged(val isVisible: Boolean) : SignOutEvent()
 }
-
-sealed class SignOutPostingEvent {
-    object Submit : SignOutPostingEvent()
-    object SignOutNavigateUp : SignOutPostingEvent()
-    object WithdrawNavigateUp : SignOutPostingEvent()
-}

--- a/core/common/src/main/java/com/sowhat/common/model/UiEvents.kt
+++ b/core/common/src/main/java/com/sowhat/common/model/UiEvents.kt
@@ -50,3 +50,14 @@ sealed class PostingEvent {
     object NavigateUp : PostingEvent()
     data class Error(val message: String) : PostingEvent()
 }
+
+sealed class SignOutEvent {
+    data class SignOutVisibilityChanged(val isVisible: Boolean) : SignOutEvent()
+    data class WithdrawVisibilityChanged(val isVisible: Boolean) : SignOutEvent()
+}
+
+sealed class SignOutPostingEvent {
+    object Submit : SignOutPostingEvent()
+    object SignOutNavigateUp : SignOutPostingEvent()
+    object WithdrawNavigateUp : SignOutPostingEvent()
+}

--- a/core/common/src/main/java/com/sowhat/common/navigation/Route.kt
+++ b/core/common/src/main/java/com/sowhat/common/navigation/Route.kt
@@ -6,6 +6,7 @@ const val CONFIGURATION = "configuration"
 
 const val SETTING = "setting"
 const val CONFIG_EDIT = "config_edit"
+const val SIGN_OUT = "sign_out"
 
 const val HOME = "home"
 

--- a/core/datastore/src/main/java/com/sowhat/datastore/AuthDataRepositoryImpl.kt
+++ b/core/datastore/src/main/java/com/sowhat/datastore/AuthDataRepositoryImpl.kt
@@ -53,6 +53,15 @@ class AuthDataRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun updateForSignOut() {
+        authDataStore.updateData { authData ->
+            authData.copy(
+                accessToken = null,
+                refreshToken = null
+            )
+        }
+    }
+
     override suspend fun resetData() {
         authDataStore.updateData { authData ->
             authData.copy(
@@ -60,8 +69,8 @@ class AuthDataRepositoryImpl @Inject constructor(
                 refreshToken = null,
                 platformToken = null,
                 platformStatus = null,
-                fcmToken = null,
-                deviceNumber = null
+//                fcmToken = null,
+//                deviceNumber = null
             )
         }
     }

--- a/core/datastore/src/main/java/com/sowhat/datastore/ProtoDataRepository.kt
+++ b/core/datastore/src/main/java/com/sowhat/datastore/ProtoDataRepository.kt
@@ -12,6 +12,7 @@ interface AuthDataRepository {
     suspend fun updateFcmToken(fcmToken: String)
     suspend fun updateDeviceNumber(deviceNumber: String)
     suspend fun updateMemberId(memberId: Long)
+    suspend fun updateForSignOut()
     suspend fun resetData()
 }
 

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/component/Cell.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/component/Cell.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.sowhat.designsystem.R
 import com.sowhat.designsystem.common.rippleClickable
+import com.sowhat.designsystem.theme.Gray600
 import com.sowhat.designsystem.theme.JustSayItTheme
 
 @Composable
@@ -33,22 +34,22 @@ fun Cell(
             .padding(
                 horizontal = 16.dp,
                 vertical = 6.dp
-            ),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween
-    ) {
-        Row(
-            modifier = Modifier.composed {
+            ).composed {
                 onClick?.let {
                     rippleClickable { onClick() }
                 } ?: this
             },
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Row(
+            modifier = Modifier,
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(0.dp)
         ) {
             leadingIcon?.let {
                 Icon(
-                    modifier = Modifier.padding(8.dp),
+                    modifier = Modifier.padding(end = 8.dp),
                     painter = painterResource(id = it),
                     contentDescription = "leadingIcon"
                 )
@@ -68,7 +69,8 @@ fun Cell(
         trailingIcon?.let {
             Icon(
                 painter = painterResource(id = it),
-                contentDescription = "leadingIcon"
+                contentDescription = "leadingIcon",
+                tint = Gray600
             )
         }
     }
@@ -88,16 +90,17 @@ fun Cell(
                 horizontal = 16.dp,
                 vertical = 4.dp
             )
-            .fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween
-    ) {
-        Row(
-            modifier = Modifier.composed {
+            .fillMaxWidth()
+            .composed {
                 onClick?.let {
                     rippleClickable { onClick() }
                 } ?: this
             },
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Row(
+            modifier = Modifier,
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween
         ) {

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/component/Dialog.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/component/Dialog.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -64,10 +65,60 @@ fun AlertDialog(
 }
 
 @Composable
+fun AlertDialogReverse(
+    modifier: Modifier = Modifier,
+    title: String,
+    subTitle: String,
+    buttonContent: Pair<String, String>,
+    onAccept: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Dialog(
+        properties = DialogProperties(),
+        onDismissRequest = onDismiss
+    ) {
+        Card(
+            modifier = modifier,
+            shape = JustSayItTheme.Shapes.medium,
+            colors = CardDefaults.cardColors(
+                containerColor =JustSayItTheme.Colors.mainBackground
+            )
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(JustSayItTheme.Spacing.spaceMd),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(28.dp)
+            ) {
+                DialogText(
+                    title = title,
+                    subTitle = subTitle
+                )
+
+                DialogButtons(
+                    buttonContent = buttonContent,
+                    onDismiss = onDismiss,
+                    onAccept = onAccept,
+                    dismissButtonColor = JustSayItTheme.Colors.subBackground,
+                    dismissTextColor = Gray500,
+                    acceptButtonColor = JustSayItTheme.Colors.mainTypo,
+                    acceptTextColor = White
+                )
+            }
+        }
+    }
+}
+
+@Composable
 private fun DialogButtons(
     buttonContent: Pair<String, String>,
     onDismiss: () -> Unit,
-    onAccept: () -> Unit
+    onAccept: () -> Unit,
+    dismissButtonColor: Color = JustSayItTheme.Colors.mainTypo,
+    dismissTextColor: Color = White,
+    acceptButtonColor: Color = JustSayItTheme.Colors.subBackground,
+    acceptTextColor: Color = Gray500
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -78,8 +129,8 @@ private fun DialogButtons(
             modifier = Modifier.weight(1f),
             text = buttonContent.first,
             textStyle = JustSayItTheme.Typography.body1,
-            textColor = White,
-            backgroundColor = JustSayItTheme.Colors.mainTypo,
+            textColor = dismissTextColor,
+            backgroundColor = dismissButtonColor,
             onClick = onDismiss
         )
 
@@ -87,8 +138,8 @@ private fun DialogButtons(
             modifier = Modifier.weight(1f),
             text = buttonContent.second,
             textStyle = JustSayItTheme.Typography.body1,
-            textColor = Gray500,
-            backgroundColor = JustSayItTheme.Colors.subBackground,
+            textColor = acceptTextColor,
+            backgroundColor = acceptButtonColor,
             onClick = onAccept
         )
     }

--- a/core/designsystem/src/main/res/values/string.xml
+++ b/core/designsystem/src/main/res/values/string.xml
@@ -49,4 +49,16 @@
     <string name="dialog_subtitle_posting">그만 작성하기를 누르면\n작성중인 글은 저장되지 않아요.</string>
     <string name="dialog_button_continue">계속 작성하기</string>
     <string name="dialog_button_stop">그만 작성하기</string>
+    
+    <string name="setting_title_normal">일반</string>
+    <string name="setting_item_contact">개발자에게 연락하기</string>
+    <string name="setting_item_terms">이용약관</string>
+    <string name="setting_item_privacy">개인정보 보호 정책</string>
+    <string name="setting_item_version">앱 버전</string>
+
+    <string name="setting_title_setting">설정</string>
+    <string name="setting_item_indie_info">개인 정보 관리</string>
+
+    <string name="setting_item_sign_out">로그아웃</string>
+    <string name="setting_item_withdraw">회원탈퇴</string>
 </resources>

--- a/core/designsystem/src/main/res/values/string.xml
+++ b/core/designsystem/src/main/res/values/string.xml
@@ -49,7 +49,14 @@
     <string name="dialog_subtitle_posting">그만 작성하기를 누르면\n작성중인 글은 저장되지 않아요.</string>
     <string name="dialog_button_continue">계속 작성하기</string>
     <string name="dialog_button_stop">그만 작성하기</string>
-    
+    <string name="dialog_title_sign_out">로그아웃</string>
+    <string name="dialog_subtitle_sign_out">로그아웃 하시겠어요?</string>
+    <string name="dialog_title_withdraw">탈퇴하기</string>
+    <string name="dialog_subtitle_withdraw">탈퇴하기를 누르면 감정 리포트,\n개인 설정 등 모든 활동 기록이 영구 삭제돼요</string>
+    <string name="dialog_button_sign_out">로그아웃</string>
+    <string name="dialog_button_withdraw">탈퇴하기</string>
+    <string name="dialog_button_cancel">취소</string>
+
     <string name="setting_title_normal">일반</string>
     <string name="setting_item_contact">개발자에게 연락하기</string>
     <string name="setting_item_terms">이용약관</string>

--- a/core/di/build.gradle.kts
+++ b/core/di/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     id("com.sowhat.justsayit.library") // app 모듈 이외에 안드로이드 라이브러리 형태로 만들어진 모듈은 application이 아닌 library를 활용
     id("com.sowhat.justsayit.application.common")
     id("com.sowhat.justsayit.application.hilt")
+    id("com.sowhat.justsayit.application.datastore")
 }
 
 android {

--- a/core/di/src/main/java/com/sowhat/di/repository/DatastoreModule.kt
+++ b/core/di/src/main/java/com/sowhat/di/repository/DatastoreModule.kt
@@ -1,4 +1,4 @@
-package com.sowhat.datastore.di
+package com.sowhat.di.repository
 
 import android.content.Context
 import androidx.datastore.core.DataStore

--- a/user/user-presentation/build.gradle.kts
+++ b/user/user-presentation/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     implementation(project(":core:designsystem"))
     implementation(project(":core:common"))
     implementation(project(":core:di"))
+    implementation(project(":core:datastore"))
     implementation(project(":core:network"))
     implementation(project(":user:user-domain"))
 

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/common/MenuItem.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/common/MenuItem.kt
@@ -9,6 +9,17 @@ data class MenuItem(
 ) {
     constructor(
         title: String,
+        onClick: (() -> Unit)? = null
+    ) : this(
+        leadingIcon = null,
+        title = title,
+        trailingIcon = null,
+        trailingText = null,
+        onClick = onClick
+    )
+
+    constructor(
+        title: String,
         trailingIcon: Int,
         onClick: (() -> Unit)? = null
     ): this(

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/common/SignOutUiState.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/common/SignOutUiState.kt
@@ -1,0 +1,7 @@
+package com.sowhat.user_presentation.common
+
+data class SignOutUiState(
+    val isLoading: Boolean = false,
+    val showSignOut: Boolean = false,
+    val showWithdraw: Boolean = false
+)

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/component/Menu.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/component/Menu.kt
@@ -15,16 +15,18 @@ import com.sowhat.user_presentation.common.MenuItem
 @Composable
 fun Menu(
     modifier: Modifier = Modifier,
-    title: String,
+    title: String?,
     menus: List<MenuItem>
 ) {
     Column(
         modifier = modifier.fillMaxWidth()
     ) {
-        Header(
-            modifier = Modifier.fillMaxWidth(),
-            title = title
-        )
+        title?.let {
+            Header(
+                modifier = Modifier.fillMaxWidth(),
+                title = title
+            )
+        }
 
         MenuItems(
             modifier = Modifier.fillMaxWidth(),
@@ -57,6 +59,14 @@ private fun MenuItems(
                     title = menuItem.title,
                     leadingIcon = menuItem.leadingIcon,
                     trailingText = menuItem.trailingText,
+                    onClick = menuItem.onClick
+                )
+            } else {
+                Cell(
+                    modifier = Modifier.fillMaxWidth(),
+                    title = menuItem.title,
+                    leadingIcon = null,
+                    trailingText = null,
                     onClick = menuItem.onClick
                 )
             }

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/navigation/UserNavigation.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/navigation/UserNavigation.kt
@@ -57,6 +57,5 @@ fun NavController.navigateToOnboarding() {
         popUpTo(SIGN_OUT) {
             inclusive = true
         }
-        launchSingleTop = true
     }
 }

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/navigation/UserNavigation.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/navigation/UserNavigation.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import com.sowhat.common.navigation.CONFIG_EDIT
+import com.sowhat.common.navigation.MAIN
 import com.sowhat.common.navigation.ONBOARDING
 import com.sowhat.common.navigation.SETTING
 import com.sowhat.common.navigation.SIGN_OUT
@@ -54,8 +55,11 @@ fun NavController.navigateToSignOut() {
 
 fun NavController.navigateToOnboarding() {
     this.navigate(ONBOARDING) {
-        popUpTo(SIGN_OUT) {
+        // popUpTo의 경우 들어가는 route는 해당 route 위에 쌓여있는 모든 화면을 빼겠다는 의미. 따라서 SIGN_OUT이 아닌 MAIN으로 명시
+        // inclusive를 true로 하면 해당 route도 포함시켜서 뺀다는 의미
+        popUpTo(MAIN) {
             inclusive = true
         }
+        launchSingleTop = true
     }
 }

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/navigation/UserNavigation.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/navigation/UserNavigation.kt
@@ -5,6 +5,7 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import com.sowhat.common.navigation.CONFIG_EDIT
+import com.sowhat.common.navigation.ONBOARDING
 import com.sowhat.common.navigation.SETTING
 import com.sowhat.common.navigation.SIGN_OUT
 import com.sowhat.user_presentation.edit.UpdateRoute
@@ -20,7 +21,9 @@ fun NavGraphBuilder.settingScreen(
 }
 
 fun NavController.navigateToUpdate() {
-    this.navigate(CONFIG_EDIT)
+    this.navigate(CONFIG_EDIT) {
+        launchSingleTop = true
+    }
 }
 
 fun NavGraphBuilder.userInfoUpdateScreen(
@@ -44,5 +47,16 @@ fun NavGraphBuilder.signOutScreen(
 }
 
 fun NavController.navigateToSignOut() {
-    this.navigate(SIGN_OUT)
+    this.navigate(SIGN_OUT) {
+        launchSingleTop = true
+    }
+}
+
+fun NavController.navigateToOnboarding() {
+    this.navigate(ONBOARDING) {
+        popUpTo(SIGN_OUT) {
+            inclusive = true
+        }
+        launchSingleTop = true
+    }
 }

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/navigation/UserNavigation.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/navigation/UserNavigation.kt
@@ -6,8 +6,10 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import com.sowhat.common.navigation.CONFIG_EDIT
 import com.sowhat.common.navigation.SETTING
+import com.sowhat.common.navigation.SIGN_OUT
 import com.sowhat.user_presentation.edit.UpdateRoute
 import com.sowhat.user_presentation.setting.SettingRoute
+import com.sowhat.user_presentation.signout.SignOutRoute
 
 fun NavGraphBuilder.settingScreen(
     appNavController: NavHostController
@@ -31,4 +33,16 @@ fun NavGraphBuilder.userInfoUpdateScreen(
 
 fun NavController.navigateUpToSetting() {
     this.popBackStack()
+}
+
+fun NavGraphBuilder.signOutScreen(
+    appNavController: NavHostController
+) {
+    composable(route = SIGN_OUT) {
+        SignOutRoute(appNavController = appNavController)
+    }
+}
+
+fun NavController.navigateToSignOut() {
+    this.navigate(SIGN_OUT)
 }

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/setting/SettingScreen.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/setting/SettingScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -34,6 +35,7 @@ import com.sowhat.user_domain.model.UserInfoDomain
 import com.sowhat.user_presentation.common.MenuItem
 import com.sowhat.user_presentation.component.Menu
 import com.sowhat.user_presentation.component.UserProfile
+import com.sowhat.user_presentation.navigation.navigateToSignOut
 import com.sowhat.user_presentation.navigation.navigateToUpdate
 
 @Composable
@@ -108,21 +110,36 @@ private fun SettingScreenContent(
 
         // TODO 메뉴 확정 시 하드코딩된 문자열들 리소스화하여 수정하기
         Menu(
-            title = "일반",
+            title = stringResource(id = R.string.setting_title_normal),
             menus = listOf(
                 MenuItem(
-                    title = "개발자에게 연락하기",
+                    title = stringResource(id = R.string.setting_item_contact),
                     trailingIcon = R.drawable.ic_next_24
                 ),
                 MenuItem(
-                    title = "이용 약관",
+                    title = stringResource(id = R.string.setting_item_terms),
                     trailingIcon = R.drawable.ic_next_24
                 ),
                 MenuItem(
-                    title = "개인정보 보호",
+                    title = stringResource(id = R.string.setting_item_privacy),
                     trailingIcon = R.drawable.ic_next_24
                 ),
-                MenuItem(title = "앱 버전", trailingText = "Ver.1.0"),
+                MenuItem(
+                    title = stringResource(id = R.string.setting_item_version),
+                    trailingText = "Ver.1.0"
+                ),
+            )
+        )
+        
+        Menu(
+            modifier = Modifier.padding(vertical = JustSayItTheme.Spacing.spaceSm),
+            title = stringResource(id = R.string.setting_title_setting),
+            menus = listOf(
+                MenuItem(
+                    title = stringResource(id = R.string.setting_item_indie_info),
+                    trailingIcon = R.drawable.ic_next_24,
+                    onClick = { appNavController.navigateToSignOut() }
+                )
             )
         )
     }

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/signout/SignOutScreen.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/signout/SignOutScreen.kt
@@ -1,5 +1,6 @@
 package com.sowhat.user_presentation.signout
 
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -45,6 +46,7 @@ fun SignOutRoute(
     )
 
     ScreenDialog(
+        appNavController = appNavController,
         uiState = uiState,
         onSignOut = viewModel::signOut,
         onWithdraw = viewModel::withdraw,
@@ -58,6 +60,7 @@ fun SignOutRoute(
             }
             is PostingEvent.NavigateUp -> {
                 appNavController.navigateToOnboarding()
+                Log.i("SignOutScreen", appNavController.visibleEntries.value.toString())
             }
         }
     }
@@ -66,6 +69,7 @@ fun SignOutRoute(
 
 @Composable
 private fun ScreenDialog(
+    appNavController: NavController,
     uiState: SignOutUiState,
     onSignOut: () -> Unit,
     onWithdraw: () -> Unit,
@@ -78,7 +82,9 @@ private fun ScreenDialog(
             buttonContent = stringResource(id = R.string.dialog_button_cancel)
                     to stringResource(id = R.string.dialog_button_sign_out),
             onAccept = onSignOut,
-            onDismiss = { onEvent(SignOutEvent.SignOutVisibilityChanged(false)) }
+            onDismiss = {
+                onEvent(SignOutEvent.SignOutVisibilityChanged(false))
+            }
         )
     }
 
@@ -89,7 +95,10 @@ private fun ScreenDialog(
             buttonContent = stringResource(id = R.string.dialog_button_cancel)
                     to stringResource(id = R.string.dialog_button_withdraw),
             onAccept = onWithdraw,
-            onDismiss = { onEvent(SignOutEvent.WithdrawVisibilityChanged(false)) }
+            onDismiss = {
+                onEvent(SignOutEvent.WithdrawVisibilityChanged(false))
+                appNavController.popBackStack()
+            }
         )
     }
 }

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/signout/SignOutScreen.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/signout/SignOutScreen.kt
@@ -1,8 +1,10 @@
 package com.sowhat.user_presentation.signout
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.contentColorFor
@@ -20,6 +22,7 @@ import com.sowhat.common.util.ObserveEvents
 import com.sowhat.designsystem.component.AppBar
 import com.sowhat.designsystem.R
 import com.sowhat.designsystem.component.AlertDialog
+import com.sowhat.designsystem.component.AlertDialogReverse
 import com.sowhat.designsystem.theme.JustSayItTheme
 import com.sowhat.user_presentation.common.MenuItem
 import com.sowhat.user_presentation.common.SignOutUiState
@@ -69,7 +72,7 @@ private fun ScreenDialog(
     onEvent: (SignOutEvent) -> Unit
 ) {
     if (uiState.showSignOut) {
-        AlertDialog(
+        AlertDialogReverse(
             title = stringResource(id = R.string.dialog_title_sign_out),
             subTitle = stringResource(id = R.string.dialog_subtitle_sign_out),
             buttonContent = stringResource(id = R.string.dialog_button_cancel)
@@ -80,11 +83,11 @@ private fun ScreenDialog(
     }
 
     if (uiState.showWithdraw) {
-        AlertDialog(
-            title = stringResource(id = R.string.dialog_title_sign_out),
-            subTitle = stringResource(id = R.string.dialog_subtitle_sign_out),
+        AlertDialogReverse(
+            title = stringResource(id = R.string.dialog_title_withdraw),
+            subTitle = stringResource(id = R.string.dialog_subtitle_withdraw),
             buttonContent = stringResource(id = R.string.dialog_button_cancel)
-                    to stringResource(id = R.string.dialog_button_sign_out),
+                    to stringResource(id = R.string.dialog_button_withdraw),
             onAccept = onWithdraw,
             onDismiss = { onEvent(SignOutEvent.WithdrawVisibilityChanged(false)) }
         )
@@ -128,10 +131,12 @@ private fun SignOutScreenContent(
         modifier = modifier
             .fillMaxSize()
             .padding(paddingValues)
+            .background(JustSayItTheme.Colors.mainBackground)
     ) {
         Menu(
             modifier = Modifier
-                .padding(vertical = JustSayItTheme.Spacing.spaceSm),
+                .padding(vertical = JustSayItTheme.Spacing.spaceSm)
+                .fillMaxWidth(),
             title = null,
             menus = listOf(
                 MenuItem(

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/signout/SignOutScreen.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/signout/SignOutScreen.kt
@@ -1,0 +1,88 @@
+package com.sowhat.user_presentation.signout
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.contentColorFor
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
+import com.sowhat.designsystem.component.AppBar
+import com.sowhat.designsystem.R
+import com.sowhat.designsystem.theme.JustSayItTheme
+import com.sowhat.user_presentation.common.MenuItem
+import com.sowhat.user_presentation.component.Menu
+import com.sowhat.user_presentation.navigation.navigateUpToSetting
+
+@Composable
+fun SignOutRoute(
+    appNavController: NavController
+) {
+    SignOutScreen(appNavController = appNavController)
+}
+
+@Composable
+fun SignOutScreen(
+    appNavController: NavController
+) {
+    Scaffold(
+        modifier = Modifier
+            .fillMaxSize(),
+        contentColor = contentColorFor(
+            backgroundColor = JustSayItTheme.Colors.mainBackground
+        ),
+        topBar = {
+            AppBar(
+                title = stringResource(id = R.string.setting_item_indie_info),
+                navigationIcon = R.drawable.ic_back_24,
+                actionIcon = null,
+                onNavigationIconClick = { appNavController.navigateUpToSetting() }
+            )
+        }
+    ) { paddingValues ->
+        SignOutScreenContent(paddingValues = paddingValues)
+    }
+}
+
+@Composable
+private fun SignOutScreenContent(
+    modifier: Modifier = Modifier,
+    paddingValues: PaddingValues
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(paddingValues)
+    ) {
+        Menu(
+            modifier = Modifier
+                .padding(vertical = JustSayItTheme.Spacing.spaceSm),
+            title = null,
+            menus = listOf(
+                MenuItem(
+                    title = stringResource(id = R.string.setting_item_sign_out),
+                    onClick = {
+                        // TODO 로그아웃 이후 화면 이동 구현
+                    }
+                ),
+                MenuItem(
+                    title = stringResource(id = R.string.setting_item_withdraw),
+                    onClick = {
+                        // TODO 회원탈퇴 성공 후 화면 이동 구현
+                    }
+                )
+            )
+        )
+    }
+}
+
+@Preview
+@Composable
+fun SignOutScreenPreview() {
+    SignOutScreen(appNavController = rememberNavController())
+}

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/signout/SignOutViewModel.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/signout/SignOutViewModel.kt
@@ -1,8 +1,8 @@
 package com.sowhat.user_presentation.signout
 
 import androidx.lifecycle.ViewModel
+import com.sowhat.common.model.PostingEvent
 import com.sowhat.common.model.SignOutEvent
-import com.sowhat.common.model.SignOutPostingEvent
 import com.sowhat.user_presentation.common.SignOutUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
@@ -20,8 +20,16 @@ class SignOutViewModel @Inject constructor(
     private var _uiState = MutableStateFlow(SignOutUiState())
     val uiState = _uiState.asStateFlow()
 
-    private val signOutEventChannel = Channel<SignOutPostingEvent>()
+    private val signOutEventChannel = Channel<PostingEvent>()
     val signOutEvent = signOutEventChannel.receiveAsFlow()
+
+    fun signOut() {
+
+    }
+
+    fun withdraw() {
+
+    }
 
     fun onEvent(event: SignOutEvent) {
         when (event) {

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/signout/SignOutViewModel.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/signout/SignOutViewModel.kt
@@ -1,8 +1,12 @@
 package com.sowhat.user_presentation.signout
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.sowhat.common.model.PostingEvent
+import com.sowhat.common.model.Resource
 import com.sowhat.common.model.SignOutEvent
+import com.sowhat.datastore.AuthDataRepository
+import com.sowhat.user_domain.use_case.WithdrawUserUseCase
 import com.sowhat.user_presentation.common.SignOutUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
@@ -10,11 +14,13 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class SignOutViewModel @Inject constructor(
-
+    private val withdrawUserUseCase: WithdrawUserUseCase,
+    private val authDataRepository: AuthDataRepository
 ) : ViewModel() {
 
     private var _uiState = MutableStateFlow(SignOutUiState())
@@ -24,11 +30,51 @@ class SignOutViewModel @Inject constructor(
     val signOutEvent = signOutEventChannel.receiveAsFlow()
 
     fun signOut() {
+        viewModelScope.launch {
+            _uiState.update {
+                uiState.value.copy(
+                    showSignOut = false,
+                )
+            }
 
+            authDataRepository.updateForSignOut()
+            signOutEventChannel.send(PostingEvent.NavigateUp)
+        }
     }
 
     fun withdraw() {
+        viewModelScope.launch {
+            _uiState.update {
+                uiState.value.copy(
+                    isLoading = true,
+                    showWithdraw = false
+                )
+            }
 
+            val result = withdrawUserUseCase()
+
+            when (result) {
+                is Resource.Success -> {
+                    _uiState.update {
+                        uiState.value.copy(
+                            isLoading = false,
+                        )
+                    }
+
+                    authDataRepository.resetData()
+                    signOutEventChannel.send(PostingEvent.NavigateUp)
+                }
+                is Resource.Error -> {
+                    _uiState.update {
+                        uiState.value.copy(
+                            isLoading = false,
+                        )
+                    }
+
+                    signOutEventChannel.send(PostingEvent.Error(message = result.message ?: ""))
+                }
+            }
+        }
     }
 
     fun onEvent(event: SignOutEvent) {

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/signout/SignOutViewModel.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/signout/SignOutViewModel.kt
@@ -1,0 +1,41 @@
+package com.sowhat.user_presentation.signout
+
+import androidx.lifecycle.ViewModel
+import com.sowhat.common.model.SignOutEvent
+import com.sowhat.common.model.SignOutPostingEvent
+import com.sowhat.user_presentation.common.SignOutUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+@HiltViewModel
+class SignOutViewModel @Inject constructor(
+
+) : ViewModel() {
+
+    private var _uiState = MutableStateFlow(SignOutUiState())
+    val uiState = _uiState.asStateFlow()
+
+    private val signOutEventChannel = Channel<SignOutPostingEvent>()
+    val signOutEvent = signOutEventChannel.receiveAsFlow()
+
+    fun onEvent(event: SignOutEvent) {
+        when (event) {
+            is SignOutEvent.SignOutVisibilityChanged -> {
+                // update : for mutablestateflow -> concurrently update
+                _uiState.update {
+                    uiState.value.copy(showSignOut = event.isVisible)
+                }
+            }
+            is SignOutEvent.WithdrawVisibilityChanged -> {
+                _uiState.update {
+                    uiState.value.copy(showWithdraw = event.isVisible)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
* 로그아웃과 회원탈퇴를 위한 컴포넌트 및 레이아웃 개발
  * 로그아웃 및 회원탈퇴 버튼을 위한 화면
  * 텍스트 셀 버튼 컴포넌트
* 로그아웃과 회원탈퇴에 따른 화면 이동 구현
  * 로그아웃 및 회원탈퇴 시, 기존의 백스택에 있던 모든 화면들을 빼고 온보딩 화면으로 이동
  * 이슈 : popUpTo의 매개변수를 잘못 설정하여 로그아웃/회원탈퇴 이후 온보딩으로 이동했을 때 뒤로가기 버튼을 눌렀을 때 다시 메인 화면으로 이동하는 오류 발생 -> popUpTo의 매개변수로 들어가는 route는 해당 백스택 내에 route 기준으로 아래가 아닌, '위에' 있는 화면들이 제거되는 것임을 깨달음
* 로그아웃 및 회원탈퇴 시 로컬에 있는 토큰 삭제 작업 진행
  * 로그아웃 시 : access token 및 refresh token 리셋
  * 회원탈퇴 시 : 모두 리셋
  * 추후 로그인할 때, platform token이 로컬에 있으면 그 platform 토큰을 그대로 사용하고(로그인), 회원탈퇴해서 없으면 해당 플랫폼으로부터 실제로 가져온 토큰으로 사용(회원가입) -> 현재 api가 platform 토큰을 바탕으로 로그인을 진행하기 때문... naver access 토큰은 현재 30분 주기로 업데이트