### PR TITLE
💄 Design: add components and screen layout for notification list

### DIFF
--- a/authentication/authentication-presentation/src/main/AndroidManifest.xml
+++ b/authentication/authentication-presentation/src/main/AndroidManifest.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application>
-        <provider
-            android:name="com.sowhat.authentication_presentation.util.ImageProvider"
-            android:authorities="com.sowhat.authentication_presentation.util.fileprovider"
-            android:grantUriPermissions="true"
-            android:exported="false">
-            <meta-data
-                android:name="android.support.FILE_PROVIDER_PATHS"
-                android:resource="@xml/file_paths" />
-        </provider>
+<!--        <provider-->
+<!--            android:name="com.sowhat.authentication_presentation.util.ImageProvider"-->
+<!--            android:authorities="com.sowhat.authentication_presentation.util.fileprovider"-->
+<!--            android:grantUriPermissions="true"-->
+<!--            android:exported="false">-->
+<!--            <meta-data-->
+<!--                android:name="android.support.FILE_PROVIDER_PATHS"-->
+<!--                android:resource="@xml/file_paths" />-->
+<!--        </provider>-->
     </application>
 </manifest>

--- a/authentication/authentication-presentation/src/main/java/com/sowhat/authentication_presentation/component/Input.kt
+++ b/authentication/authentication-presentation/src/main/java/com/sowhat/authentication_presentation/component/Input.kt
@@ -1,5 +1,6 @@
 package com.sowhat.authentication_presentation.component
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -23,13 +24,16 @@ fun DobTextField(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .padding(JustSayItTheme.Spacing.spaceBase),
+            .padding(JustSayItTheme.Spacing.spaceBase)
+            .background(JustSayItTheme.Colors.mainBackground),
         verticalArrangement = Arrangement.spacedBy(JustSayItTheme.Spacing.spaceSm)
     ) {
         DefaultHeader(title = title)
 
         Row(
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(JustSayItTheme.Colors.mainBackground)
         ) {
             items.forEachIndexed { index, item ->
                 if (index != 0) Spacer(modifier = Modifier.width(JustSayItTheme.Spacing.spaceXXS))

--- a/authentication/authentication-presentation/src/main/java/com/sowhat/authentication_presentation/component/Selection.kt
+++ b/authentication/authentication-presentation/src/main/java/com/sowhat/authentication_presentation/component/Selection.kt
@@ -1,5 +1,6 @@
 package com.sowhat.authentication_presentation.component
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -26,7 +27,8 @@ fun Selection(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .padding(JustSayItTheme.Spacing.spaceBase),
+            .padding(JustSayItTheme.Spacing.spaceBase)
+            .background(JustSayItTheme.Colors.mainBackground),
         verticalArrangement = Arrangement.spacedBy(JustSayItTheme.Spacing.spaceSm)
     ) {
         DefaultHeader(title = title)

--- a/authentication/authentication-presentation/src/main/java/com/sowhat/authentication_presentation/configuration/UserConfigScreen.kt
+++ b/authentication/authentication-presentation/src/main/java/com/sowhat/authentication_presentation/configuration/UserConfigScreen.kt
@@ -1,5 +1,6 @@
 package com.sowhat.authentication_presentation.configuration
 
+import android.content.res.Configuration
 import android.net.Uri
 import android.util.Log
 import android.view.ViewTreeObserver
@@ -178,7 +179,8 @@ fun UserConfigScreen(
     Scaffold(
         modifier = modifier
             .fillMaxSize()
-            .noRippleClickable { keyboardController?.hide() },
+            .noRippleClickable { keyboardController?.hide() }
+            .background(JustSayItTheme.Colors.mainBackground),
         topBar = {
             AppBar(
                 title = null,
@@ -255,6 +257,7 @@ fun UserConfigScreen(
 }
 
 @Preview
+@Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 fun UserConfigScreenPreview() {
     var id by rememberSaveable {

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/component/AppBar.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/component/AppBar.kt
@@ -53,44 +53,61 @@ fun AppBar(
     onNavigationIconClick: () -> Unit = {},
     onActionIconClick: () -> Unit = {}
 ) {
-    CenterAlignedTopAppBar(
-        modifier = modifier
-            .height(48.dp)
-            .bottomBorder(strokeWidth = 1.dp, color = JustSayItTheme.Colors.subSurface),
-        colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = JustSayItTheme.Colors.mainSurface,
-        ),
-        title = { 
-            title?.let {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        text = title,
-                        style = JustSayItTheme.Typography.body1,
-                        color = JustSayItTheme.Colors.mainTypo
+    Box(
+        modifier
+            .fillMaxWidth()
+            .height(48.dp),
+//        .bottomBorder(
+//            strokeWidth = 1.dp,
+//            color = Gray500
+//        ),
+        contentAlignment = Alignment.BottomCenter
+    ) {
+        CenterAlignedTopAppBar(
+            modifier = modifier
+                .height(48.dp)
+                .bottomBorder(strokeWidth = 1.dp, color = JustSayItTheme.Colors.subSurface),
+            colors = TopAppBarDefaults.topAppBarColors(
+                containerColor = JustSayItTheme.Colors.mainSurface,
+            ),
+            title = {
+                title?.let {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = title,
+                            style = JustSayItTheme.Typography.body1,
+                            color = JustSayItTheme.Colors.mainTypo
+                        )
+                    }
+                }
+            },
+            navigationIcon = {
+                navigationIcon?.let {
+                    DefaultIconButton(
+                        iconDrawable = navigationIcon,
+                        onClick = onNavigationIconClick
                     )
                 }
-            }
-        },
-        navigationIcon = {
-            navigationIcon?.let {
-                DefaultIconButton(
-                    iconDrawable = navigationIcon,
-                    onClick = onNavigationIconClick
-                )
-            }
-        },
-        actions = {
-            actionIcon?.let {
-                DefaultIconButton(
-                    iconDrawable = actionIcon,
-                    onClick = onActionIconClick
-                )
-            }
-        },
-    )
+            },
+            actions = {
+                actionIcon?.let {
+                    DefaultIconButton(
+                        iconDrawable = actionIcon,
+                        onClick = onActionIconClick
+                    )
+                }
+            },
+        )
+
+        Divider(
+            modifier = Modifier.fillMaxWidth(),
+            thickness = 1.dp,
+            color = JustSayItTheme.Colors.subBackground
+        )
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -104,45 +121,63 @@ fun AppBar(
     onNavigationIconClick: () -> Unit = {},
     onActionTextClick: () -> Unit = {}
 ) {
-    CenterAlignedTopAppBar(
-        modifier = modifier
-            .height(48.dp)
-            .bottomBorder(strokeWidth = 1.dp, color = JustSayItTheme.Colors.subSurface),
-        colors = TopAppBarDefaults.topAppBarColors(
-            containerColor = JustSayItTheme.Colors.mainSurface,
-        ),
-        title = {
-            title?.let {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Text(
-                        text = title,
-                        style = JustSayItTheme.Typography.body1,
-                        color = JustSayItTheme.Colors.mainTypo
+    Box(
+        modifier
+            .fillMaxWidth()
+            .height(48.dp),
+//        .bottomBorder(
+//            strokeWidth = 1.dp,
+//            color = Gray500
+//        ),
+        contentAlignment = Alignment.BottomCenter
+    ) {
+        CenterAlignedTopAppBar(
+            modifier = modifier
+                .height(48.dp)
+                .bottomBorder(strokeWidth = 1.dp, color = JustSayItTheme.Colors.subSurface),
+            colors = TopAppBarDefaults.topAppBarColors(
+                containerColor = JustSayItTheme.Colors.mainSurface,
+            ),
+            title = {
+                title?.let {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Text(
+                            text = title,
+                            style = JustSayItTheme.Typography.body1,
+                            color = JustSayItTheme.Colors.mainTypo
+                        )
+                    }
+                }
+            },
+            navigationIcon = {
+                navigationIcon?.let {
+                    DefaultIconButton(
+                        iconDrawable = navigationIcon,
+                        onClick = onNavigationIconClick
+                    )
+                }
+            },
+            actions = {
+                actionText?.let {
+                    DefaultTextButton(
+                        text = actionText,
+                        onClick = onActionTextClick,
+                        textStyle = textStyle
                     )
                 }
             }
-        },
-        navigationIcon = {
-            navigationIcon?.let {
-                DefaultIconButton(
-                    iconDrawable = navigationIcon,
-                    onClick = onNavigationIconClick
-                )
-            }
-        },
-        actions = {
-            actionText?.let {
-                DefaultTextButton(
-                    text = actionText,
-                    onClick = onActionTextClick,
-                    textStyle = textStyle
-                )
-            }
-        }
-    )
+        )
+
+        Divider(
+            modifier = Modifier.fillMaxWidth(),
+            thickness = 1.dp,
+            color = JustSayItTheme.Colors.subBackground
+        )
+
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/component/AppBar.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/component/AppBar.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
 import androidx.compose.ui.text.TextStyle
@@ -51,7 +52,8 @@ fun AppBar(
     navigationIcon: Int?,
     actionIcon: Int?,
     onNavigationIconClick: () -> Unit = {},
-    onActionIconClick: () -> Unit = {}
+    onActionIconClick: () -> Unit = {},
+    bottomBorder: Boolean = false
 ) {
     Box(
         modifier
@@ -66,7 +68,11 @@ fun AppBar(
         CenterAlignedTopAppBar(
             modifier = modifier
                 .height(48.dp)
-                .bottomBorder(strokeWidth = 1.dp, color = JustSayItTheme.Colors.subSurface),
+                .composed {
+                    if (bottomBorder) {
+                        bottomBorder(strokeWidth = 0.5.dp, color = JustSayItTheme.Colors.subSurface)
+                    } else this
+                },
             colors = TopAppBarDefaults.topAppBarColors(
                 containerColor = JustSayItTheme.Colors.mainSurface,
             ),
@@ -102,11 +108,13 @@ fun AppBar(
             },
         )
 
-        Divider(
-            modifier = Modifier.fillMaxWidth(),
-            thickness = 1.dp,
-            color = JustSayItTheme.Colors.subBackground
-        )
+        if (bottomBorder) {
+            Divider(
+                modifier = Modifier.fillMaxWidth(),
+                thickness = 1.dp,
+                color = JustSayItTheme.Colors.subBackground
+            )
+        }
     }
 }
 
@@ -119,7 +127,8 @@ fun AppBar(
     navigationIcon: Int?,
     actionText: String?,
     onNavigationIconClick: () -> Unit = {},
-    onActionTextClick: () -> Unit = {}
+    onActionTextClick: () -> Unit = {},
+    bottomBorder: Boolean = false
 ) {
     Box(
         modifier
@@ -134,7 +143,7 @@ fun AppBar(
         CenterAlignedTopAppBar(
             modifier = modifier
                 .height(48.dp)
-                .bottomBorder(strokeWidth = 1.dp, color = JustSayItTheme.Colors.subSurface),
+                .bottomBorder(strokeWidth = 0.5.dp, color = JustSayItTheme.Colors.subSurface),
             colors = TopAppBarDefaults.topAppBarColors(
                 containerColor = JustSayItTheme.Colors.mainSurface,
             ),
@@ -171,12 +180,13 @@ fun AppBar(
             }
         )
 
-        Divider(
-            modifier = Modifier.fillMaxWidth(),
-            thickness = 1.dp,
-            color = JustSayItTheme.Colors.subBackground
-        )
-
+        if (bottomBorder) {
+            Divider(
+                modifier = Modifier.fillMaxWidth(),
+                thickness = 1.dp,
+                color = JustSayItTheme.Colors.subBackground
+            )
+        }
     }
 }
 
@@ -195,7 +205,7 @@ fun AppBar(
     CenterAlignedTopAppBar(
         modifier = modifier
             .height(48.dp)
-            .bottomBorder(strokeWidth = 1.dp, color = JustSayItTheme.Colors.subSurface),
+            .bottomBorder(strokeWidth = 0.5.dp, color = JustSayItTheme.Colors.subSurface),
         colors = TopAppBarDefaults.topAppBarColors(
             containerColor = JustSayItTheme.Colors.mainSurface,
         ),
@@ -246,7 +256,7 @@ fun AppBarHome(
     CenterAlignedTopAppBar(
         modifier = modifier
             .height(48.dp)
-            .bottomBorder(strokeWidth = 1.dp, color = JustSayItTheme.Colors.subSurface),
+            .bottomBorder(strokeWidth = 0.5.dp, color = JustSayItTheme.Colors.subSurface),
         colors = TopAppBarDefaults.topAppBarColors(
             containerColor = JustSayItTheme.Colors.mainSurface,
         ),
@@ -291,7 +301,7 @@ fun AppBarHome(
     CenterAlignedTopAppBar(
         modifier = modifier
             .height(48.dp)
-            .bottomBorder(strokeWidth = 1.dp, color = JustSayItTheme.Colors.subSurface),
+            .bottomBorder(strokeWidth = 0.5.dp, color = JustSayItTheme.Colors.subSurface),
         colors = TopAppBarDefaults.topAppBarColors(
             containerColor = JustSayItTheme.Colors.mainSurface,
         ),
@@ -362,7 +372,7 @@ fun AppBarFeed(
 
         Divider(
             modifier = Modifier.fillMaxWidth(),
-            thickness = 1.dp,
+            thickness = 0.5.dp,
             color = JustSayItTheme.Colors.subBackground
         )
     }
@@ -466,7 +476,7 @@ private fun EmotionButtons(
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
-class ScrollBehavior: TopAppBarScrollBehavior {
+class ScrollBehavior : TopAppBarScrollBehavior {
     override val flingAnimationSpec: DecayAnimationSpec<Float> = TODO()
     override val isPinned: Boolean = TODO()
     override val nestedScrollConnection: NestedScrollConnection = TODO()
@@ -496,13 +506,17 @@ fun AppBarPreview() {
     var currentItem by remember {
         mutableStateOf(dropdownItems.first())
     }
-    
+
     var currentTabItem by remember {
         mutableStateOf(tabItems.first())
     }
 
     Column {
-        AppBar(title = "설정", navigationIcon = R.drawable.ic_back_24, actionIcon = R.drawable.ic_menu_24)
+        AppBar(
+            title = "설정",
+            navigationIcon = R.drawable.ic_back_24,
+            actionIcon = R.drawable.ic_menu_24
+        )
         Spacer(modifier = Modifier.height(2.dp))
         AppBar(title = "앱바 미리보기", navigationIcon = R.drawable.ic_back_24, actionText = "완료")
         Spacer(modifier = Modifier.height(2.dp))
@@ -510,10 +524,12 @@ fun AppBarPreview() {
         Spacer(modifier = Modifier.height(2.dp))
         AppBarHome(onClick = {}, currentEmotion = Emotion.HAPPY)
         Spacer(modifier = Modifier.height(2.dp))
-        AppBarHome(title = "그냥, 그렇다고", actions = listOf(
-            ActionButtonItem(icon = R.drawable.ic_camera_24, onClick = {}),
-            ActionButtonItem(icon = R.drawable.ic_menu_24, onClick = {})
-        ))
+        AppBarHome(
+            title = "그냥, 그렇다고", actions = listOf(
+                ActionButtonItem(icon = R.drawable.ic_camera_24, onClick = {}),
+                ActionButtonItem(icon = R.drawable.ic_menu_24, onClick = {})
+            )
+        )
         Spacer(modifier = Modifier.height(2.dp))
         AppBarFeed(
             currentDropdownItem = currentItem,

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/component/ProfileImage.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/component/ProfileImage.kt
@@ -38,6 +38,7 @@ fun ProfileImage(
                 top = 40.dp,
                 bottom = 20.dp
             )
+            .background(JustSayItTheme.Colors.mainBackground)
     ) {
         val (profile, badge) = createRefs()
 
@@ -87,6 +88,7 @@ fun ProfileImage(
                 top = 40.dp,
                 bottom = 20.dp
             )
+            .background(JustSayItTheme.Colors.mainBackground)
     ) {
         val (profile, badge) = createRefs()
 

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/component/TextField.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/component/TextField.kt
@@ -127,7 +127,8 @@ private fun DefaultTextFieldContent(
         value = value,
         singleLine = true,
         onValueChange = onValueChange,
-        textStyle = JustSayItTheme.Typography.heading3,
+        textStyle = JustSayItTheme.Typography.heading3
+            .copy(color = JustSayItTheme.Colors.mainTypo),
         decorationBox = { innerTextField ->
             Box(
                 modifier = Modifier

--- a/core/designsystem/src/main/res/values/string.xml
+++ b/core/designsystem/src/main/res/values/string.xml
@@ -44,6 +44,7 @@
     <string name="error_server">서버 에러</string>
 
     <string name="appbar_post">게시글 쓰기</string>
+    <string name="appbar_notification">알림</string>
     
     <string name="dialog_title_posting">작성중인 글이 있어요.</string>
     <string name="dialog_subtitle_posting">그만 작성하기를 누르면\n작성중인 글은 저장되지 않아요.</string>

--- a/feed/feed-presentation/src/main/java/com/sowhat/feed_presentation/feeds/FeedScreen.kt
+++ b/feed/feed-presentation/src/main/java/com/sowhat/feed_presentation/feeds/FeedScreen.kt
@@ -61,7 +61,8 @@ fun FeedScreen(
 
     Scaffold(
         modifier = modifier
-            .fillMaxSize(),
+            .fillMaxSize()
+            .background(JustSayItTheme.Colors.mainBackground),
         topBar = {
             AnimatedVisibility(
                 visible = lazyListState.isScrollingUp(),

--- a/notification/notification-presentation/src/main/java/com/practice/notification_presentation/component/Notification.kt
+++ b/notification/notification-presentation/src/main/java/com/practice/notification_presentation/component/Notification.kt
@@ -1,0 +1,105 @@
+package com.practice.notification_presentation.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import com.sowhat.designsystem.theme.Gray400
+import com.sowhat.designsystem.theme.JustSayItTheme
+
+@Composable
+fun Notification(
+    // TODO api 나오면 데이터 클래스로 만들어서 매개변수 수 줄이기
+    modifier: Modifier = Modifier,
+    title: String,
+    content: String,
+    time: String,
+    drawable: Int,
+    statusText: String,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(JustSayItTheme.Spacing.spaceBase)
+            .background(JustSayItTheme.Colors.mainBackground)
+    ) {
+        // 감정 상태
+        MoodStatus(
+            drawable = drawable,
+            statusText = statusText
+        )
+
+        // 알림 내용
+        NotificationContent(
+            title = title,
+            content = content,
+            time = time
+        )
+    }
+}
+
+@Composable
+private fun NotificationContent(title: String, content: String, time: String) {
+    Column(
+        modifier = Modifier
+            .padding(top = JustSayItTheme.Spacing.spaceXXS)
+    ) {
+        Text(
+            text = title,
+            style = JustSayItTheme.Typography.body1,
+            color = JustSayItTheme.Colors.mainTypo,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+
+        Spacer(modifier = Modifier.height(JustSayItTheme.Spacing.spaceXXS))
+
+        Text(
+            text = content,
+            style = JustSayItTheme.Typography.detail1,
+            color = JustSayItTheme.Colors.subTypo,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+
+        Spacer(modifier = Modifier.height(JustSayItTheme.Spacing.spaceTiny))
+
+        Text(
+            text = time,
+            style = JustSayItTheme.Typography.detail1,
+            color = Gray400,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+@Composable
+private fun MoodStatus(drawable: Int, statusText: String) {
+    Column(
+        verticalArrangement = Arrangement.spacedBy(JustSayItTheme.Spacing.spaceXXS)
+    ) {
+        Image(
+            painter = painterResource(id = drawable),
+            contentDescription = "status"
+        )
+
+        Text(
+            text = statusText,
+            style = JustSayItTheme.Typography.detail1,
+            color = JustSayItTheme.Colors.mainTypo,
+            textAlign = TextAlign.Center
+        )
+    }
+}

--- a/notification/notification-presentation/src/main/java/com/practice/notification_presentation/component/Notification.kt
+++ b/notification/notification-presentation/src/main/java/com/practice/notification_presentation/component/Notification.kt
@@ -9,12 +9,15 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import com.sowhat.designsystem.theme.Gray400
 import com.sowhat.designsystem.theme.JustSayItTheme
 
@@ -32,7 +35,9 @@ fun Notification(
         modifier = modifier
             .fillMaxWidth()
             .padding(JustSayItTheme.Spacing.spaceBase)
-            .background(JustSayItTheme.Colors.mainBackground)
+            .background(JustSayItTheme.Colors.mainBackground),
+        horizontalArrangement = Arrangement
+            .spacedBy(JustSayItTheme.Spacing.spaceXS)
     ) {
         // 감정 상태
         MoodStatus(
@@ -53,7 +58,8 @@ fun Notification(
 private fun NotificationContent(title: String, content: String, time: String) {
     Column(
         modifier = Modifier
-            .padding(top = JustSayItTheme.Spacing.spaceXXS)
+            .padding(top = JustSayItTheme.Spacing.spaceXXS),
+        verticalArrangement = Arrangement.spacedBy(JustSayItTheme.Spacing.spaceXXS)
     ) {
         Text(
             text = title,
@@ -63,8 +69,6 @@ private fun NotificationContent(title: String, content: String, time: String) {
             overflow = TextOverflow.Ellipsis,
         )
 
-        Spacer(modifier = Modifier.height(JustSayItTheme.Spacing.spaceXXS))
-
         Text(
             text = content,
             style = JustSayItTheme.Typography.detail1,
@@ -72,8 +76,6 @@ private fun NotificationContent(title: String, content: String, time: String) {
             maxLines = 1,
             overflow = TextOverflow.Ellipsis
         )
-
-        Spacer(modifier = Modifier.height(JustSayItTheme.Spacing.spaceTiny))
 
         Text(
             text = time,
@@ -88,9 +90,11 @@ private fun NotificationContent(title: String, content: String, time: String) {
 @Composable
 private fun MoodStatus(drawable: Int, statusText: String) {
     Column(
-        verticalArrangement = Arrangement.spacedBy(JustSayItTheme.Spacing.spaceXXS)
+        verticalArrangement = Arrangement.spacedBy(JustSayItTheme.Spacing.spaceXXS),
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Image(
+            modifier = Modifier.size(40.dp),
             painter = painterResource(id = drawable),
             contentDescription = "status"
         )

--- a/notification/notification-presentation/src/main/java/com/practice/notification_presentation/notifications/NotificationScreen.kt
+++ b/notification/notification-presentation/src/main/java/com/practice/notification_presentation/notifications/NotificationScreen.kt
@@ -34,7 +34,8 @@ fun NotificationScreen() {
             AppBar(
                 title = stringResource(id = R.string.appbar_notification),
                 navigationIcon = null,
-                actionIcon = null
+                actionIcon = null,
+                bottomBorder = true
             )
         }
     ) { paddingValues ->

--- a/notification/notification-presentation/src/main/java/com/practice/notification_presentation/notifications/NotificationScreen.kt
+++ b/notification/notification-presentation/src/main/java/com/practice/notification_presentation/notifications/NotificationScreen.kt
@@ -1,11 +1,21 @@
 package com.practice.notification_presentation.notifications
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.navigation.NavController
+import com.practice.notification_presentation.component.Notification
+import com.sowhat.designsystem.component.AppBar
+import com.sowhat.designsystem.theme.JustSayItTheme
+import com.sowhat.designsystem.R
 
 @Composable
 fun NotificationRoute(
@@ -16,7 +26,38 @@ fun NotificationRoute(
 
 @Composable
 fun NotificationScreen() {
-    Scaffold { paddingValues ->
-        Box(modifier = Modifier.padding(paddingValues))
+    Scaffold(
+        modifier = Modifier
+            .fillMaxSize(),
+        contentColor = contentColorFor(backgroundColor = JustSayItTheme.Colors.mainBackground),
+        topBar = {
+            AppBar(
+                title = stringResource(id = R.string.appbar_notification),
+                navigationIcon = null,
+                actionIcon = null
+            )
+        }
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier
+                .padding(paddingValues)
+                .background(JustSayItTheme.Colors.mainBackground),
+        ) {
+            items(20) {
+                Notification(
+                    title = "오늘은 피그마 파일 하나를 공유하려고 합니다...",
+                    content = "글에 공감이 추가되었어요.",
+                    time = "1분 전",
+                    drawable = R.drawable.ic_happy_96,
+                    statusText = "행복"
+                )
+            }
+        }
     }
+}
+
+@Preview
+@Composable
+fun NotificationScreenPreview() {
+    NotificationScreen()
 }


### PR DESCRIPTION
* 하단 내비게이션바 메뉴 중, "알림" 메뉴의 화면을 위한 컴포넌트 및 레이아웃 구현
* 특별한 이슈 없음
  * 아이템 컴포넌트 추가
  * 앱바 및 LazyColumn으로 구성된 레이아웃 추가
  * 앱바의 하단 경계선 굵기 1.dp -> 0.5.dp로 변경