### PR TITLE
✨💄 Feat: add my page components and layout related to report

### DIFF
--- a/authentication/authentication-presentation/src/main/java/com/sowhat/authentication_presentation/component/SignIn.kt
+++ b/authentication/authentication-presentation/src/main/java/com/sowhat/authentication_presentation/component/SignIn.kt
@@ -14,7 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import com.sowhat.designsystem.component.LoginIconButton
+import com.sowhat.designsystem.component.ImageButton
 import com.sowhat.designsystem.theme.Gray300
 import com.sowhat.designsystem.theme.Gray600
 import com.sowhat.designsystem.theme.JustSayItTheme
@@ -79,8 +79,8 @@ fun SignInButtons(
             horizontalArrangement = Arrangement.spacedBy(20.dp)
         ) {
             signInPlatforms.forEach {
-                LoginIconButton(
-                    iconDrawable = it.iconDrawable,
+                ImageButton(
+                    imageDrawable = it.iconDrawable,
                     onClick = it.onClick
                 )
             }

--- a/build-logic/convention/src/main/kotlin/com/sowhat/convention/ComposeAndroid.kt
+++ b/build-logic/convention/src/main/kotlin/com/sowhat/convention/ComposeAndroid.kt
@@ -21,6 +21,7 @@ internal fun Project.configureComposeAndroid() {
 
             add("implementation", libs.findLibrary("material3").get())
             add("implementation", libs.findLibrary("ui").get())
+            implementation(libs, "ui.util")
             add("implementation", libs.findLibrary("ui.tooling.preview").get())
             add("androidTestImplementation", libs.findLibrary("androidx.test.ext.junit").get())
             add("androidTestImplementation", libs.findLibrary("espresso.core").get())

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/common/Border.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/common/Border.kt
@@ -8,8 +8,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PaintingStyle.Companion.Stroke
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -53,3 +57,25 @@ fun Modifier.topBorder(strokeWidth: Dp, color: Color, horizontalPadding: Dp = 0.
         }
     }
 )
+
+
+
+fun Modifier.dashedBorder(width: Float, color: Color, cornerRadius: Dp) = composed (
+    factory = {
+        val dashedStroke = Stroke(
+            width = width,
+            pathEffect = PathEffect.dashPathEffect(floatArrayOf(5f, 5f), 0f)
+        )
+
+        Modifier.drawBehind {
+            drawRoundRect(
+                color = color,
+                style = dashedStroke,
+                cornerRadius = CornerRadius(cornerRadius.toPx())
+            )
+        }
+    }
+)
+
+
+

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/common/Mood.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/common/Mood.kt
@@ -1,0 +1,25 @@
+package com.sowhat.designsystem.common
+
+import com.sowhat.designsystem.R
+
+const val MOOD_HAPPY = "FEELING001"
+const val MOOD_SAD = "FEELING002"
+const val MOOD_SURPRISED = "FEELING003"
+const val MOOD_ANGRY = "FEELING004"
+
+enum class Mood(
+    val title: String,
+    val postData: String,
+    val drawable: Int
+) {
+    HAPPY("행복", MOOD_HAPPY, R.drawable.ic_happy_96),
+    SAD("슬픔", MOOD_SAD, R.drawable.ic_sad_96),
+    SURPRISED("놀람", MOOD_SURPRISED, R.drawable.ic_surprise_96),
+    ANGRY("화남", MOOD_ANGRY, R.drawable.ic_angry_96);
+
+    companion object {
+        fun getMoodDataByTitle(queryTitle: String): Mood? {
+            return Mood.values().find { it.title == queryTitle }
+        }
+    }
+}

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/component/AppBar.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/component/AppBar.kt
@@ -70,7 +70,7 @@ fun AppBar(
                 .height(48.dp)
                 .composed {
                     if (bottomBorder) {
-                        bottomBorder(strokeWidth = 0.5.dp, color = JustSayItTheme.Colors.subSurface)
+                        bottomBorder(strokeWidth = JustSayItTheme.Spacing.border, color = JustSayItTheme.Colors.subSurface)
                     } else this
                 },
             colors = TopAppBarDefaults.topAppBarColors(
@@ -143,7 +143,7 @@ fun AppBar(
         CenterAlignedTopAppBar(
             modifier = modifier
                 .height(48.dp)
-                .bottomBorder(strokeWidth = 0.5.dp, color = JustSayItTheme.Colors.subSurface),
+                .bottomBorder(strokeWidth = JustSayItTheme.Spacing.border, color = JustSayItTheme.Colors.subSurface),
             colors = TopAppBarDefaults.topAppBarColors(
                 containerColor = JustSayItTheme.Colors.mainSurface,
             ),
@@ -205,7 +205,7 @@ fun AppBar(
     CenterAlignedTopAppBar(
         modifier = modifier
             .height(48.dp)
-            .bottomBorder(strokeWidth = 0.5.dp, color = JustSayItTheme.Colors.subSurface),
+            .bottomBorder(strokeWidth = JustSayItTheme.Spacing.border, color = JustSayItTheme.Colors.subSurface),
         colors = TopAppBarDefaults.topAppBarColors(
             containerColor = JustSayItTheme.Colors.mainSurface,
         ),
@@ -256,7 +256,7 @@ fun AppBarHome(
     CenterAlignedTopAppBar(
         modifier = modifier
             .height(48.dp)
-            .bottomBorder(strokeWidth = 0.5.dp, color = JustSayItTheme.Colors.subSurface),
+            .bottomBorder(strokeWidth = JustSayItTheme.Spacing.border, color = JustSayItTheme.Colors.subSurface),
         colors = TopAppBarDefaults.topAppBarColors(
             containerColor = JustSayItTheme.Colors.mainSurface,
         ),
@@ -301,7 +301,7 @@ fun AppBarHome(
     CenterAlignedTopAppBar(
         modifier = modifier
             .height(48.dp)
-            .bottomBorder(strokeWidth = 0.5.dp, color = JustSayItTheme.Colors.subSurface),
+            .bottomBorder(strokeWidth = JustSayItTheme.Spacing.border, color = JustSayItTheme.Colors.subSurface),
         colors = TopAppBarDefaults.topAppBarColors(
             containerColor = JustSayItTheme.Colors.mainSurface,
         ),
@@ -372,7 +372,7 @@ fun AppBarFeed(
 
         Divider(
             modifier = Modifier.fillMaxWidth(),
-            thickness = 0.5.dp,
+            thickness = JustSayItTheme.Spacing.border,
             color = JustSayItTheme.Colors.subBackground
         )
     }

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/component/Dropdown.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/component/Dropdown.kt
@@ -99,7 +99,7 @@ fun DropdownContents(
                     color = JustSayItTheme.Colors.mainSurface,
                 )
                 .border(
-                    width = 0.5.dp,
+                    width = JustSayItTheme.Spacing.border,
                     color = Gray300,
                     shape = JustSayItTheme.Shapes.medium
                 ),
@@ -127,7 +127,7 @@ fun ColumnScope.DropdownMenus(
 ) {
     items.forEachIndexed { index, dropdownItem ->
         if (index != 0) Divider(
-            thickness = 0.5.dp,
+            thickness = JustSayItTheme.Spacing.border,
             color = Gray300,
         )
 

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/component/IconButton.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/component/IconButton.kt
@@ -30,13 +30,17 @@ fun DefaultIconButton(
 }
 
 @Composable
-fun LoginIconButton(
-    iconDrawable: Int,
+fun ImageButton(
+    modifier: Modifier = Modifier,
+    imageDrawable: Int,
     onClick: () -> Unit
 ) {
-    IconButton(onClick = onClick) {
+    IconButton(
+        modifier = modifier,
+        onClick = onClick
+    ) {
         Image(
-            painter = painterResource(id = iconDrawable),
+            painter = painterResource(id = imageDrawable),
             contentDescription = "login icon"
         )
     }
@@ -50,8 +54,8 @@ fun DefaultIconButtonPreview() {
             iconDrawable = R.drawable.ic_camera_24,
             onClick = {}
         )
-        LoginIconButton(
-            iconDrawable = R.drawable.ic_naver_24,
+        ImageButton(
+            imageDrawable = R.drawable.ic_naver_24,
             onClick = {}
         )
     }

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/component/Image.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/component/Image.kt
@@ -92,7 +92,7 @@ fun SquaredImageContainer(
 ) {
     ImageContainer(
         modifier = modifier.aspectRatio(1f),
-        borderWidth = 0.5.dp,
+        borderWidth = JustSayItTheme.Spacing.border,
         borderColor = JustSayItTheme.Colors.subSurface,
         shape = JustSayItTheme.Shapes.large,
         model = model,
@@ -108,7 +108,7 @@ fun TimelineFeedImageContainer(
 ) {
     ImageContainer(
         modifier = modifier,
-        borderWidth = 0.5.dp,
+        borderWidth = JustSayItTheme.Spacing.border,
         borderColor = JustSayItTheme.Colors.subSurface,
         shape = JustSayItTheme.Shapes.medium,
         model = model,

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/component/Tab.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/component/Tab.kt
@@ -60,7 +60,7 @@ fun RowScope.TabDivider() {
     Divider(
         modifier = Modifier
             .padding(vertical = JustSayItTheme.Spacing.spaceXS)
-            .width(0.5.dp)
+            .width(JustSayItTheme.Spacing.border)
             .fillMaxHeight(),
         color = Gray200
     )

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/component/Text.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/component/Text.kt
@@ -71,12 +71,14 @@ fun TextDrawableStart(
 
 @Composable
 fun TextDrawableEnd(
+    modifier: Modifier = Modifier,
     text: String,
     textStyle: TextStyle,
     textColor: Color,
     drawable: Int?
 ) {
     Row(
+        modifier = modifier,
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/theme/Dimension.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/theme/Dimension.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.unit.dp
 
 data class JustSayItDimension(
     val default: Dp = 0.dp,
+    val border: Dp = 0.5.dp,
     val spaceTiny: Dp = 2.dp,
     val spaceXXS: Dp = 4.dp,
     val spaceXS: Dp = 8.dp,

--- a/core/designsystem/src/main/res/values/string.xml
+++ b/core/designsystem/src/main/res/values/string.xml
@@ -63,6 +63,8 @@
     <string name="report_subtitle">%s님,\n지금 기분이 어떠신가요?</string>
 
     <string name="report_view_report">분석 레포트 보러가기</string>
+    <string name="report_badge_public">공개</string>
+    <string name="report_badge_private">비공개</string>
 
     <string name="setting_title_normal">일반</string>
     <string name="setting_item_contact">개발자에게 연락하기</string>

--- a/core/designsystem/src/main/res/values/string.xml
+++ b/core/designsystem/src/main/res/values/string.xml
@@ -62,6 +62,8 @@
     <string name="report_title">오랜만이에요.</string>
     <string name="report_subtitle">%s님,\n지금 기분이 어떠신가요?</string>
 
+    <string name="report_view_report">분석 레포트 보러가기</string>
+
     <string name="setting_title_normal">일반</string>
     <string name="setting_item_contact">개발자에게 연락하기</string>
     <string name="setting_item_terms">이용약관</string>

--- a/core/designsystem/src/main/res/values/string.xml
+++ b/core/designsystem/src/main/res/values/string.xml
@@ -37,6 +37,7 @@
 
     <string name="button_start">시작하기</string>
     <string name="button_post">게시하기</string>
+    <string name="button_feeling_submit">감정 제출</string>
 
     <string name="dropdown_upload_image">사진 업로드하기</string>
     <string name="dropdown_default_image">기본 이미지로 변경</string>
@@ -57,6 +58,9 @@
     <string name="dialog_button_sign_out">로그아웃</string>
     <string name="dialog_button_withdraw">탈퇴하기</string>
     <string name="dialog_button_cancel">취소</string>
+
+    <string name="report_title">오랜만이에요.</string>
+    <string name="report_subtitle">%s님,\n지금 기분이 어떠신가요?</string>
 
     <string name="setting_title_normal">일반</string>
     <string name="setting_item_contact">개발자에게 연락하기</string>

--- a/feed/feed-presentation/src/main/java/com/sowhat/feed_presentation/component/Feed.kt
+++ b/feed/feed-presentation/src/main/java/com/sowhat/feed_presentation/component/Feed.kt
@@ -60,7 +60,7 @@ fun Feed(
             .fillMaxWidth()
             .background(color = JustSayItTheme.Colors.mainBackground)
             // bottomBorder 순서가 padding 앞에 와야 경계선이 아이템의 최하단에 형성
-            .bottomBorder(0.5.dp, Gray300, JustSayItTheme.Spacing.spaceBase)
+            .bottomBorder(JustSayItTheme.Spacing.border, Gray300, JustSayItTheme.Spacing.spaceBase)
             .padding(vertical = JustSayItTheme.Spacing.spaceBase),
         verticalArrangement = Arrangement
             .spacedBy(JustSayItTheme.Spacing.spaceBase)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -71,6 +71,7 @@ lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtim
 activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
 compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
 ui = { group = "androidx.compose.ui", name = "ui" }
+ui-util = { group = "androidx.compose.ui", name = "ui-util", version.ref = "composeRuntime" }
 ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
 ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }

--- a/main/main-presentation/src/main/java/com/sowhat/main_presentation/component/Navigation.kt
+++ b/main/main-presentation/src/main/java/com/sowhat/main_presentation/component/Navigation.kt
@@ -71,7 +71,7 @@ fun BottomNavigationBar(
                 .fillMaxWidth()
                 .fillMaxHeight(0.8f)
                 .background(JustSayItTheme.Colors.mainBackground)
-                .topBorder(strokeWidth = 0.5.dp, color = Gray300),
+                .topBorder(strokeWidth = JustSayItTheme.Spacing.border, color = Gray300),
 //            .border(width = 0.5.dp, color = Gray300)
             containerColor = bottomNavBackground
 //            containerColor = JustSayItTheme.Colors.mainSurface,

--- a/post/post-presentation/src/main/java/com/sowhat/post_presentation/component/ImageSelection.kt
+++ b/post/post-presentation/src/main/java/com/sowhat/post_presentation/component/ImageSelection.kt
@@ -49,7 +49,7 @@ fun ImageSelection(
             modifier = Modifier
                 .aspectRatio(1f)
                 .border(
-                    width = 0.5.dp,
+                    width = JustSayItTheme.Spacing.border,
                     color = JustSayItTheme.Colors.subSurface,
                     shape = JustSayItTheme.Shapes.medium
                 )
@@ -64,7 +64,7 @@ fun ImageSelection(
                 modifier = modifier
                     .aspectRatio(1f)
                     .border(
-                        width = 0.5.dp,
+                        width = JustSayItTheme.Spacing.border,
                         color = JustSayItTheme.Colors.subSurface,
                         shape = JustSayItTheme.Shapes.medium
                     )
@@ -100,7 +100,7 @@ fun SquaredPostImageContainer(
 
         ImageContainer(
             modifier = Modifier,
-            borderWidth = 0.5.dp,
+            borderWidth = JustSayItTheme.Spacing.border,
             borderColor = JustSayItTheme.Colors.subSurface,
             shape = JustSayItTheme.Shapes.medium,
             model = model,

--- a/report/report-presentation/src/main/java/com/sowhat/report_presentation/component/Badge.kt
+++ b/report/report-presentation/src/main/java/com/sowhat/report_presentation/component/Badge.kt
@@ -1,0 +1,78 @@
+package com.sowhat.report_presentation.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.sowhat.designsystem.theme.Gray300
+import com.sowhat.designsystem.theme.JustSayItTheme
+import com.sowhat.designsystem.R
+
+@Composable
+fun OpenStatusBadge(
+    modifier: Modifier = Modifier,
+    isOpen: Boolean
+) {
+    Row(
+        modifier = modifier
+            .width(76.dp)
+            .height(28.dp)
+            .clip(JustSayItTheme.Shapes.medium)
+            .border(
+                width = JustSayItTheme.Spacing.border,
+                color = Gray300,
+                shape = JustSayItTheme.Shapes.medium
+            )
+            .background(JustSayItTheme.Colors.mainBackground)
+            .padding(
+                top = JustSayItTheme.Spacing.spaceXXS,
+                bottom = JustSayItTheme.Spacing.spaceXXS,
+                start = JustSayItTheme.Spacing.spaceXS,
+                end = JustSayItTheme.Spacing.spaceSm
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement
+            .spacedBy(JustSayItTheme.Spacing.spaceXXS)
+    ) {
+        val drawable = if (isOpen) R.drawable.ic_unlock_16 else R.drawable.ic_lock_16
+        val textRes = if (isOpen) R.string.report_badge_public else R.string.report_badge_private
+
+        Icon(
+            painter = painterResource(id = drawable),
+            contentDescription = "is_open",
+            tint = JustSayItTheme.Colors.inactiveTypo
+        )
+
+        Text(
+            modifier = Modifier.width(JustSayItTheme.Spacing.spaceXL),
+            text = stringResource(id = textRes),
+            textAlign = TextAlign.End,
+            style = JustSayItTheme.Typography.detail1,
+            color = JustSayItTheme.Colors.mainTypo
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun OpenBadgePreview() {
+    Column {
+        OpenStatusBadge(isOpen = true)
+        OpenStatusBadge(isOpen = false)
+    }
+}

--- a/report/report-presentation/src/main/java/com/sowhat/report_presentation/component/Badge.kt
+++ b/report/report-presentation/src/main/java/com/sowhat/report_presentation/component/Badge.kt
@@ -3,6 +3,7 @@ package com.sowhat.report_presentation.component
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.height
@@ -14,11 +15,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.sowhat.designsystem.theme.Gray300
 import com.sowhat.designsystem.theme.JustSayItTheme
 import com.sowhat.designsystem.R
@@ -33,12 +36,12 @@ fun OpenStatusBadge(
             .width(76.dp)
             .height(28.dp)
             .clip(JustSayItTheme.Shapes.medium)
+            .background(JustSayItTheme.Colors.mainBackground)
             .border(
                 width = JustSayItTheme.Spacing.border,
                 color = Gray300,
                 shape = JustSayItTheme.Shapes.medium
             )
-            .background(JustSayItTheme.Colors.mainBackground)
             .padding(
                 top = JustSayItTheme.Spacing.spaceXXS,
                 bottom = JustSayItTheme.Spacing.spaceXXS,
@@ -68,6 +71,30 @@ fun OpenStatusBadge(
     }
 }
 
+@Composable
+fun DateBadge(
+    modifier: Modifier = Modifier,
+    date: String
+) {
+    Box(
+        modifier = modifier
+            .clip(JustSayItTheme.Shapes.medium)
+            .background(JustSayItTheme.Colors.mainTypo.copy(alpha = 0.5f))
+    ) {
+        Text(
+            modifier = Modifier
+                .padding(
+                    horizontal = JustSayItTheme.Spacing.spaceXS,
+                    vertical = JustSayItTheme.Spacing.spaceXXS
+                ),
+            text = date,
+            style = JustSayItTheme.Typography.detail1.copy(fontSize = 10.sp, lineHeight = 16.sp),
+            color = JustSayItTheme.Colors.mainBackground
+        )
+    }
+}
+
+
 @Preview(showBackground = true)
 @Composable
 fun OpenBadgePreview() {
@@ -75,4 +102,10 @@ fun OpenBadgePreview() {
         OpenStatusBadge(isOpen = true)
         OpenStatusBadge(isOpen = false)
     }
+}
+
+@Preview
+@Composable
+fun DateBadgePreview() {
+    DateBadge(date = "98.11.23")
 }

--- a/report/report-presentation/src/main/java/com/sowhat/report_presentation/component/CurrentMood.kt
+++ b/report/report-presentation/src/main/java/com/sowhat/report_presentation/component/CurrentMood.kt
@@ -1,0 +1,34 @@
+package com.sowhat.report_presentation.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.sowhat.designsystem.common.Mood
+
+@Composable
+fun CurrentMood(
+    modifier: Modifier = Modifier,
+    mood: Mood
+) {
+    Image(
+        modifier = modifier.size(80.dp),
+        painter = painterResource(id = mood.drawable),
+        contentDescription = "mood"
+    )
+}
+
+@Preview
+@Composable
+fun CurrentMoodPreview() {
+    Column {
+        CurrentMood(mood = Mood.HAPPY)
+        CurrentMood(mood = Mood.SAD)
+        CurrentMood(mood = Mood.SURPRISED)
+        CurrentMood(mood = Mood.ANGRY)
+    }
+}

--- a/report/report-presentation/src/main/java/com/sowhat/report_presentation/component/CurrentMoodSelection.kt
+++ b/report/report-presentation/src/main/java/com/sowhat/report_presentation/component/CurrentMoodSelection.kt
@@ -1,0 +1,37 @@
+package com.sowhat.report_presentation.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.sowhat.designsystem.common.Mood
+import com.sowhat.designsystem.component.ImageButton
+import com.sowhat.designsystem.theme.JustSayItTheme
+
+@Composable
+fun CurrentMoodSelection(
+    modifier: Modifier = Modifier,
+    availableMoods: List<Mood>,
+    onChange: (Mood) -> Unit
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement
+            .spacedBy(
+                space = JustSayItTheme.Spacing.spaceMd,
+                alignment = Alignment.CenterHorizontally
+            )
+    ) {
+        availableMoods.forEach { mood ->
+            ImageButton(
+                modifier = Modifier.size(36.dp),
+                imageDrawable = mood.drawable,
+                onClick = { onChange(mood) }
+            )
+        }
+    }
+}

--- a/report/report-presentation/src/main/java/com/sowhat/report_presentation/component/DailySelection.kt
+++ b/report/report-presentation/src/main/java/com/sowhat/report_presentation/component/DailySelection.kt
@@ -1,0 +1,148 @@
+package com.sowhat.report_presentation.component
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PageSize
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.lerp
+import com.sowhat.designsystem.common.Mood
+import com.sowhat.designsystem.common.dashedBorder
+import com.sowhat.designsystem.theme.Gray500
+import com.sowhat.designsystem.theme.JustSayItTheme
+import java.nio.channels.Selector
+import kotlin.math.absoluteValue
+
+@Composable
+fun DateSelection(
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth(),
+        contentAlignment = Alignment.BottomCenter
+    ) {
+        CurrentMoodSection()
+        SelectionSlider(modifier = Modifier.fillMaxSize())
+    }
+}
+
+@Composable
+private fun CurrentMoodSection(
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .size(100.dp)
+            .clip(JustSayItTheme.Shapes.medium)
+            .dashedBorder(
+                width = 5f,
+                color = Gray500,
+                cornerRadius = JustSayItTheme.Spacing.spaceSm
+            ),
+        contentAlignment = Alignment.Center,
+        content = {}
+    )
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun SelectionSlider(
+    modifier: Modifier = Modifier
+) {
+    // TODO API 나오면 고치기
+    var pagerCount = 25
+    val pagerState = rememberPagerState(
+        initialPage = 20 // 끝 페이지부터 시작
+    ) {
+        pagerCount
+    }
+
+    val itemSize = 92.dp
+
+    val configuration = LocalConfiguration.current
+    val screenWidthDp = configuration.screenWidthDp.dp
+
+    // https://medium.com/@domen.lanisnik/exploring-the-official-pager-in-compose-8c2698c49a98
+    HorizontalPager(
+        modifier = modifier.fillMaxWidth(),
+        state = pagerState,
+        pageSize = PageSize.Fixed(itemSize),
+        verticalAlignment = Alignment.Bottom,
+        // 현재 아이템 위치를 중앙으로 맞추기 위함
+        contentPadding = PaddingValues(
+            start = screenWidthDp / 2 - itemSize / 2,
+            end = screenWidthDp / 2 - itemSize / 2
+        )
+    ) {pageIdx ->
+        Column(
+            modifier = Modifier
+                .width(itemSize) // 기본적으로 아이템들이 왼쪽에 치우쳐 있으므로
+                .graphicsLayer {
+                    val pageOffset = (
+                            (pagerState.currentPage - pageIdx) +
+                                    pagerState.currentPageOffsetFraction).absoluteValue
+
+                    // We animate the alpha, between 50% and 100%
+                    alpha = lerp(
+                        start = 0.5f,
+                        stop = 1f,
+                        fraction = 1f - pageOffset.coerceIn(0f, 1f)
+                    )
+                }
+                .padding(bottom = 10.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Text(
+                modifier = Modifier
+                    .composed {
+                        if (pagerState.currentPage == pageIdx) {
+                            padding(bottom = JustSayItTheme.Spacing.spaceBase)
+                        } else padding(bottom = JustSayItTheme.Spacing.spaceXS)
+                    },
+                text = "12:00",
+                style = JustSayItTheme.Typography.detail1,
+                color = Gray500,
+            )
+
+            CurrentMood(
+                mood = Mood.HAPPY,
+                modifier = Modifier.composed {
+                    if (pagerState.currentPage == pageIdx) {
+                        size(80.dp)
+                    } else size(48.dp)
+                }
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, backgroundColor = 0xffffffff)
+@Composable
+fun DailySectionPreview() {
+    Column {
+        DateSelection(modifier = Modifier.height(126.dp))
+    }
+}

--- a/report/report-presentation/src/main/java/com/sowhat/report_presentation/component/DateSelection.kt
+++ b/report/report-presentation/src/main/java/com/sowhat/report_presentation/component/DateSelection.kt
@@ -1,11 +1,9 @@
 package com.sowhat.report_presentation.component
 
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -22,17 +20,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.lerp
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.util.lerp
 import com.sowhat.designsystem.common.Mood
 import com.sowhat.designsystem.common.dashedBorder
 import com.sowhat.designsystem.theme.Gray500
 import com.sowhat.designsystem.theme.JustSayItTheme
-import java.nio.channels.Selector
 import kotlin.math.absoluteValue
 
 @Composable
@@ -80,10 +75,11 @@ fun SelectionSlider(
         pagerCount
     }
 
-    val itemSize = 92.dp
+    val itemSize = 84.dp
 
     val configuration = LocalConfiguration.current
-    val screenWidthDp = configuration.screenWidthDp.dp
+    // 64dp는 Card 및 화면 상에서 사용되는 총 horizontal padding
+    val screenWidthDp = configuration.screenWidthDp.dp - 64.dp
 
     // https://medium.com/@domen.lanisnik/exploring-the-official-pager-in-compose-8c2698c49a98
     HorizontalPager(

--- a/report/report-presentation/src/main/java/com/sowhat/report_presentation/component/MyFeed.kt
+++ b/report/report-presentation/src/main/java/com/sowhat/report_presentation/component/MyFeed.kt
@@ -25,10 +25,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import com.sowhat.designsystem.R
 import com.sowhat.designsystem.common.MoodItem
 import com.sowhat.designsystem.common.noRippleClickable
-import com.sowhat.designsystem.common.rippleClickable
 import com.sowhat.designsystem.component.TimelineFeedImages
 import com.sowhat.designsystem.theme.JustSayItTheme
 
@@ -37,24 +37,42 @@ fun MyFeed(
     modifier: Modifier = Modifier,
     isPrivate: Boolean,
     mood: MoodItem,
+    date: String,
     isStatusVisible: Boolean,
     onMenuClick: () -> Unit,
     text: String,
-    images: List<String>
+    images: List<String>,
+    isScrollInProgress: Boolean
 ) {
-    Row(
+    Box(
         modifier = modifier
             .fillMaxWidth()
-            .background(color = Color.Transparent),
-        horizontalArrangement = Arrangement
-            .spacedBy(JustSayItTheme.Spacing.spaceXS)
+            .background(color = Color.Transparent)
     ) {
-        MoodStatus(
-            mood = mood,
-            isStatusVisible = isStatusVisible
-        )
 
-        FeedCard(isPrivate, onMenuClick, text, images)
+        if (isStatusVisible && isScrollInProgress) {
+            DateBadge(
+                modifier = Modifier
+                    .padding(top = 48.dp)
+                    .zIndex(2f),
+                date = date
+            )
+        }
+
+        Row(
+            modifier = modifier
+                .fillMaxWidth()
+                .background(color = Color.Transparent),
+            horizontalArrangement = Arrangement
+                .spacedBy(JustSayItTheme.Spacing.spaceXS)
+        ) {
+            MoodStatus(
+                mood = mood,
+                isStatusVisible = isStatusVisible
+            )
+
+            FeedCard(isPrivate, onMenuClick, text, images)
+        }
     }
 }
 
@@ -146,20 +164,8 @@ private fun MenuButton(onMenuClick: () -> Unit) {
 }
 
 @Composable
-private fun PrivateStatus(isPrivate: Boolean) {
-    if (isPrivate) {
-        Icon(
-            painter = painterResource(id = R.drawable.ic_lock_16),
-            contentDescription = "locked",
-            tint = JustSayItTheme.Colors.inactiveTypo
-        )
-    } else {
-        Icon(
-            painter = painterResource(id = R.drawable.ic_unlock_16),
-            contentDescription = "unlocked",
-            tint = JustSayItTheme.Colors.inactiveTypo
-        )
-    }
+private fun PrivateStatus(isOpen: Boolean) {
+    OpenStatusBadge(isOpen = isOpen)
 }
 
 @Composable
@@ -199,7 +205,9 @@ fun MyFeedPreview() {
                 isStatusVisible = true,
                 text = "ok\nok",
                 images = emptyList(),
-                onMenuClick = {}
+                onMenuClick = {},
+                date = "22.11.22",
+                isScrollInProgress = true
             )
             
             Spacer(modifier = Modifier.height(JustSayItTheme.Spacing.spaceBase))
@@ -214,7 +222,9 @@ fun MyFeedPreview() {
                 isStatusVisible = true,
                 text = "ok\nok",
                 images = listOf("", "", ""),
-                onMenuClick = {}
+                onMenuClick = {},
+                date = "22.11.23",
+                isScrollInProgress = true
             )
         }
     }

--- a/report/report-presentation/src/main/java/com/sowhat/report_presentation/component/RailBackground.kt
+++ b/report/report-presentation/src/main/java/com/sowhat/report_presentation/component/RailBackground.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import com.sowhat.designsystem.common.MoodItem
 import com.sowhat.designsystem.theme.Gray200
 import com.sowhat.designsystem.theme.JustSayItTheme
@@ -34,6 +35,8 @@ fun RailBackground(
     modifier: Modifier = Modifier,
     lazyListState: LazyListState,
     currentMood: MoodItem,
+    currentDate: String,
+    isScrollInProgress: Boolean,
     content: @Composable () -> Unit
 ) {
     Box(
@@ -51,6 +54,16 @@ fun RailBackground(
                 ),
             mood = currentMood,
             isStatusVisible = true
+        )
+
+        DateBadge(
+            modifier = Modifier
+                .padding(
+                    start = JustSayItTheme.Spacing.spaceSm,
+                    top = JustSayItTheme.Spacing.spaceExtraExtraLarge
+                )
+                .zIndex(2f),
+            date = currentDate
         )
 
         content()
@@ -93,9 +106,17 @@ fun RailBackgroundPreview() {
         )
     }
 
+    var currentDate by remember {
+        mutableStateOf(
+            "24.01.27"
+        )
+    }
+
     RailBackground(
         lazyListState = lazyListState,
-        currentMood = currentState
+        currentMood = currentState,
+        currentDate = currentDate,
+        isScrollInProgress = lazyListState.isScrollInProgress
     ) {
         LazyColumn(
             modifier = Modifier
@@ -132,7 +153,9 @@ fun RailBackgroundPreview() {
                     isStatusVisible = if (remember { derivedStateOf { lazyListState.firstVisibleItemIndex } }.value == index) isItemIconVisible.value else true,
                     text = "ok\nok",
                     images = emptyList(),
-                    onMenuClick = {}
+                    onMenuClick = {},
+                    date = "22.11.23",
+                    isScrollInProgress = lazyListState.isScrollInProgress
                 )
 
                 Spacer(modifier = Modifier.height(JustSayItTheme.Spacing.spaceBase))

--- a/report/report-presentation/src/main/java/com/sowhat/report_presentation/component/Report.kt
+++ b/report/report-presentation/src/main/java/com/sowhat/report_presentation/component/Report.kt
@@ -2,6 +2,7 @@ package com.sowhat.report_presentation.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -15,10 +16,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.sowhat.designsystem.theme.JustSayItTheme
 import com.sowhat.designsystem.R
+import com.sowhat.designsystem.R.drawable.ic_next_16
+import com.sowhat.designsystem.common.Mood
+import com.sowhat.designsystem.common.rippleClickable
 import com.sowhat.designsystem.component.DefaultButtonFull
+import com.sowhat.designsystem.component.TextDrawableEnd
 import com.sowhat.designsystem.theme.Gray500
 
 @Composable
@@ -38,10 +44,28 @@ fun Report(
             .spacedBy(JustSayItTheme.Spacing.spaceBase)
     ) {
         ReportTitle(nickname = nickname)
-
         ReportCard(isActive = isActive)
+        ReportButton(onClick = {})
+    }
+}
 
-
+@Composable
+fun ReportButton(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit
+) {
+    Box(
+        modifier = modifier.fillMaxWidth(),
+        contentAlignment = Alignment.CenterEnd
+    ) {
+        TextDrawableEnd(
+            modifier = Modifier
+                .rippleClickable { onClick() },
+            text = stringResource(id = R.string.report_view_report),
+            textStyle = JustSayItTheme.Typography.body3,
+            textColor = JustSayItTheme.Colors.mainTypo,
+            drawable = ic_next_16
+        )
     }
 }
 
@@ -102,9 +126,11 @@ private fun ReportCard(
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(JustSayItTheme.Spacing.spaceBase)
             ) {
-                // TODO 슬라이더
+                // 슬라이더
+                DateSelection()
 
-                // TODO 감정 선택 버튼
+                // 감정 선택 버튼
+                CurrentMoodSelection(availableMoods = Mood.values().toList(), onChange = {})
             }
 
             DefaultButtonFull(
@@ -114,4 +140,10 @@ private fun ReportCard(
             )
         }
     }
+}
+
+@Preview
+@Composable
+fun ReportPreview() {
+    Report(nickname = "케이엠", isActive = true)
 }

--- a/report/report-presentation/src/main/java/com/sowhat/report_presentation/component/Report.kt
+++ b/report/report-presentation/src/main/java/com/sowhat/report_presentation/component/Report.kt
@@ -1,17 +1,117 @@
 package com.sowhat.report_presentation.component
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.sowhat.designsystem.theme.JustSayItTheme
+import com.sowhat.designsystem.R
+import com.sowhat.designsystem.component.DefaultButtonFull
+import com.sowhat.designsystem.theme.Gray500
 
 @Composable
 fun Report(
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    nickname: String,
+    isActive: Boolean,
 ) {
     Column(
-        modifier = modifier.aspectRatio(1f)
+        modifier = modifier
+            .padding(
+                horizontal = JustSayItTheme.Spacing.spaceBase,
+                vertical = JustSayItTheme.Spacing.spaceLg
+            )
+            .background(JustSayItTheme.Colors.mainBackground),
+        verticalArrangement = Arrangement
+            .spacedBy(JustSayItTheme.Spacing.spaceBase)
     ) {
+        ReportTitle(nickname = nickname)
 
+        ReportCard(isActive = isActive)
+
+
+    }
+}
+
+@Composable
+private fun ReportTitle(
+    modifier: Modifier = Modifier,
+    nickname: String,
+) {
+    Column(
+        modifier = modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement
+            .spacedBy(JustSayItTheme.Spacing.spaceXXS)
+    ) {
+        Text(
+            text = stringResource(id = R.string.report_title),
+            style = JustSayItTheme.Typography.body2,
+            color = Gray500
+        )
+
+        Text(
+            text = stringResource(id = R.string.report_subtitle, nickname),
+            style = JustSayItTheme.Typography.heading2,
+            color = JustSayItTheme.Colors.mainTypo,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
+        )
+    }
+}
+
+@Composable
+private fun ReportCard(
+    modifier: Modifier = Modifier,
+    isActive: Boolean,
+) {
+    Card(
+        modifier = modifier
+            .fillMaxWidth(),
+        shape = JustSayItTheme.Shapes.medium,
+        elevation = CardDefaults.cardElevation(defaultElevation = 10.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = JustSayItTheme.Colors.mainBackground,
+            contentColor = contentColorFor(backgroundColor = JustSayItTheme.Colors.mainBackground)
+        )
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(
+                    horizontal = JustSayItTheme.Spacing.spaceBase,
+                    vertical = JustSayItTheme.Spacing.spaceXL
+                ),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(JustSayItTheme.Spacing.spaceLg)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = JustSayItTheme.Spacing.spaceLg),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(JustSayItTheme.Spacing.spaceBase)
+            ) {
+                // TODO 슬라이더
+
+                // TODO 감정 선택 버튼
+            }
+
+            DefaultButtonFull(
+                text = stringResource(id = R.string.button_feeling_submit),
+                isActive = isActive,
+                onClick = {}
+            )
+        }
     }
 }

--- a/report/report-presentation/src/main/java/com/sowhat/report_presentation/mypage/MyPageScreen.kt
+++ b/report/report-presentation/src/main/java/com/sowhat/report_presentation/mypage/MyPageScreen.kt
@@ -71,6 +71,14 @@ fun MyPageScreen(
                     )
                 }
 
+                val isScrollInProgress = lazyListState.isScrollInProgress
+
+                var currentDate by remember {
+                    mutableStateOf(
+                        "24.01.27"
+                    )
+                }
+
                 AppBarMyPage(
                     currentDropdownItem = DropdownItem("전체"),
                     dropdownItems = listOf(),
@@ -86,7 +94,9 @@ fun MyPageScreen(
 
                 RailBackground(
                     lazyListState = lazyListState,
-                    currentMood = currentState
+                    currentMood = currentState,
+                    currentDate = currentDate,
+                    isScrollInProgress = isScrollInProgress
                 ) {
                     LazyColumn(
                         modifier = Modifier
@@ -123,7 +133,9 @@ fun MyPageScreen(
                                 isStatusVisible = if (remember { derivedStateOf { lazyListState.firstVisibleItemIndex } }.value == index) isItemIconVisible.value else true,
                                 text = "ok\nok",
                                 images = emptyList(),
-                                onMenuClick = {}
+                                onMenuClick = {},
+                                date = "22.11.23",
+                                isScrollInProgress = isScrollInProgress
                             )
 
                             Spacer(modifier = Modifier.height(JustSayItTheme.Spacing.spaceBase))

--- a/report/report-presentation/src/main/java/com/sowhat/report_presentation/mypage/MyPageScreen.kt
+++ b/report/report-presentation/src/main/java/com/sowhat/report_presentation/mypage/MyPageScreen.kt
@@ -53,7 +53,7 @@ fun MyPageScreen(
             modifier = Modifier.padding(paddingValues),
             state = nestedScrollViewState,
             header = {
-                Report()
+                // Report()
             }
         ) {
             Column(

--- a/report/report-presentation/src/main/java/com/sowhat/report_presentation/mypage/MyPageScreen.kt
+++ b/report/report-presentation/src/main/java/com/sowhat/report_presentation/mypage/MyPageScreen.kt
@@ -53,7 +53,7 @@ fun MyPageScreen(
             modifier = Modifier.padding(paddingValues),
             state = nestedScrollViewState,
             header = {
-                // Report()
+                Report(Modifier,"케이엠", true)
             }
         ) {
             Column(

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/setting/SettingScreen.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/setting/SettingScreen.kt
@@ -104,7 +104,7 @@ private fun SettingScreenContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(vertical = JustSayItTheme.Spacing.spaceSm),
-            thickness = 0.5.dp,
+            thickness = JustSayItTheme.Spacing.border,
             color = JustSayItTheme.Colors.subBackground
         )
 


### PR DESCRIPTION
* "내 글" 메뉴에서의 리포트 영역 관련 컴포넌트 및 레이아웃 제작
* 슬라이딩 관련 레이아웃 : HorizontalPager 활용
* 개발 과정 이슈
  * 현재 선택된 아이템이 중앙에 위치하지 않고 화면 끝으로 치우치는 현상
    * 아이템의 가로 크기 고정 + HorizontalPager의 contentPadding 매개변수로 해결
      * 아이템(Column으로 구성)의 너비를 디자인 상의 80dp보다 약간 넉넉한 크기의 84dp로 고정 후 내부에 들어가는 요소들에 대해서는 가운데 정렬 처리
      * 기기로부터 화면의 너비값을 구한 후, start 및 end padding값을 기기 너비 / 2 - 아이템 너비 / 2로 주어, 선택된 요소가 가운데로 위치하도록 처리하였음
  * 선택된 아이템인지 아닌지에 따라 이모지의 크기 및 텍스트와의 간격을 달리 해야 하는 요구사항 구현
    * Compose 측에서 제공하는 rememberPagerState를 활용
    * Modifier의 composed 속성을 활용 -> 조건문을 활용하여 padding값 및 size값을 분기처리
  * 주변에 보이는 선택되지 않은 아이템의 경우 alpha값을 낮춰야 하는 요구사항
    * Modifier의 graphicsLayer 속성 활용
    ```
    graphicsLayer {
                    val pageOffset = (
                            (pagerState.currentPage - pageIdx) +
                                    pagerState.currentPageOffsetFraction).absoluteValue

                    // We animate the alpha, between 50% and 100%
                    alpha = lerp(
                        start = 0.5f,
                        stop = 1f,
                        fraction = 1f - pageOffset.coerceIn(0f, 1f)
                    )
                }
    ```