### PR TITLE
✨ Feat: add menu click events on setting screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,7 +47,9 @@
     <queries>
         <intent>
             <action android:name="android.intent.action.SEND" />
-            <data android:mimeType="text/plain" />
+            <data
+                android:mimeType="text/plain"
+                android:scheme="mailto" />
         </intent>
     </queries>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -44,4 +44,11 @@
         </activity>
     </application>
 
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.SEND" />
+            <data android:mimeType="text/plain" />
+        </intent>
+    </queries>
+
 </manifest>

--- a/authentication/authentication-presentation/src/main/java/com/sowhat/authentication_presentation/component/Term.kt
+++ b/authentication/authentication-presentation/src/main/java/com/sowhat/authentication_presentation/component/Term.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextAlign
@@ -14,6 +15,7 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
+import com.sowhat.designsystem.R
 import com.sowhat.designsystem.theme.JustSayItTheme
 
 @Composable
@@ -53,14 +55,14 @@ fun TermText(
 
         addStringAnnotation(
             tag = "URL",
-            annotation = "https://www.notion.so/56e7a2cd2c2746078c11dacf984c941b",
+            annotation = stringResource(id = R.string.service_term_url),
             start = 9,
             end = 13
         )
 
         addStringAnnotation(
             tag = "URL",
-            annotation = "https://www.notion.so/803c054f70bb44398d677780da66f982",
+            annotation = stringResource(id = R.string.service_privacy_url),
             start = 15,
             end = 27
         )

--- a/core/designsystem/src/main/res/values/string.xml
+++ b/core/designsystem/src/main/res/values/string.xml
@@ -94,4 +94,9 @@
 
     <string name="setting_item_sign_out">로그아웃</string>
     <string name="setting_item_withdraw">회원탈퇴</string>
+
+    <string name="service_email">justtsayit2024@gmail.com</string>
+    <string name="contact_subject">그냥, 그렇다고 서비스 문의</string>
+    <string name="service_term_url">https://www.notion.so/56e7a2cd2c2746078c11dacf984c941b</string>
+    <string name="service_privacy_url">https://www.notion.so/803c054f70bb44398d677780da66f982</string>
 </resources>

--- a/core/designsystem/src/main/res/values/string.xml
+++ b/core/designsystem/src/main/res/values/string.xml
@@ -99,4 +99,6 @@
     <string name="contact_subject">그냥, 그렇다고 서비스 문의</string>
     <string name="service_term_url">https://www.notion.so/56e7a2cd2c2746078c11dacf984c941b</string>
     <string name="service_privacy_url">https://www.notion.so/803c054f70bb44398d677780da66f982</string>
+
+    <string name="contact_select_email_app">문의사항을 보낼 애플리케이션을 선택해주세요.</string>
 </resources>

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/setting/SettingScreen.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/setting/SettingScreen.kt
@@ -1,5 +1,7 @@
 package com.sowhat.user_presentation.setting
 
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -16,15 +18,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.rememberNavController
 import com.sowhat.common.model.UiState
-import com.sowhat.common.util.LaunchWhenCreated
-import com.sowhat.common.util.LaunchWhenStarted
 import com.sowhat.designsystem.R
 import com.sowhat.designsystem.common.BUTTON_EDIT_PROFILE
 import com.sowhat.designsystem.common.APPBAR_SETTING
@@ -94,6 +94,16 @@ private fun SettingScreenContent(
 ) {
     val scrollState = rememberScrollState()
 
+    val context = LocalContext.current
+    val contactIntent = Intent(Intent.ACTION_SEND).apply {
+        type = "text/plain"
+        putExtra(Intent.EXTRA_EMAIL, arrayOf(stringResource(id = R.string.service_email)))
+        putExtra(Intent.EXTRA_SUBJECT, stringResource(id = R.string.contact_subject))
+    }
+
+    val termPageIntent = getWebPageIntent(url = stringResource(id = R.string.service_term_url))
+    val privacyPageIntent = getWebPageIntent(url = stringResource(id = R.string.service_privacy_url))
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -113,21 +123,35 @@ private fun SettingScreenContent(
             color = JustSayItTheme.Colors.subBackground
         )
 
-        // TODO 메뉴 확정 시 하드코딩된 문자열들 리소스화하여 수정하기
         Menu(
             title = stringResource(id = R.string.setting_title_normal),
             menus = listOf(
                 MenuItem(
                     title = stringResource(id = R.string.setting_item_contact),
-                    trailingIcon = R.drawable.ic_next_24
+                    trailingIcon = R.drawable.ic_next_24,
+                    onClick = {
+                        if (contactIntent.resolveActivity(context.packageManager) != null) {
+                            context.startActivity(contactIntent)
+                        }
+                    }
                 ),
                 MenuItem(
                     title = stringResource(id = R.string.setting_item_terms),
-                    trailingIcon = R.drawable.ic_next_24
+                    trailingIcon = R.drawable.ic_next_24,
+                    onClick = {
+                        if (contactIntent.resolveActivity(context.packageManager) != null) {
+                            context.startActivity(termPageIntent)
+                        }
+                    }
                 ),
                 MenuItem(
                     title = stringResource(id = R.string.setting_item_privacy),
-                    trailingIcon = R.drawable.ic_next_24
+                    trailingIcon = R.drawable.ic_next_24,
+                    onClick = {
+                        if (contactIntent.resolveActivity(context.packageManager) != null) {
+                            context.startActivity(privacyPageIntent)
+                        }
+                    }
                 ),
                 MenuItem(
                     title = stringResource(id = R.string.setting_item_version),
@@ -149,6 +173,9 @@ private fun SettingScreenContent(
         )
     }
 }
+
+@Composable
+private fun getWebPageIntent(url: String) = Intent(Intent.ACTION_VIEW, Uri.parse(url))
 
 @Composable
 private fun ProfileSection(

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/setting/SettingScreen.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/setting/SettingScreen.kt
@@ -95,14 +95,14 @@ private fun SettingScreenContent(
     val scrollState = rememberScrollState()
 
     val context = LocalContext.current
-    val contactIntent = Intent(Intent.ACTION_SEND).apply {
+    val emailIntent = Intent(Intent.ACTION_SEND).apply {
         type = "text/plain"
         putExtra(Intent.EXTRA_EMAIL, arrayOf(stringResource(id = R.string.service_email)))
         putExtra(Intent.EXTRA_SUBJECT, stringResource(id = R.string.contact_subject))
     }
-
     val termPageIntent = getWebPageIntent(url = stringResource(id = R.string.service_term_url))
     val privacyPageIntent = getWebPageIntent(url = stringResource(id = R.string.service_privacy_url))
+    val emailSelectorText = stringResource(id = R.string.contact_select_email_app)
 
     Column(
         modifier = modifier
@@ -130,16 +130,14 @@ private fun SettingScreenContent(
                     title = stringResource(id = R.string.setting_item_contact),
                     trailingIcon = R.drawable.ic_next_24,
                     onClick = {
-                        if (contactIntent.resolveActivity(context.packageManager) != null) {
-                            context.startActivity(contactIntent)
-                        }
+                        context.startActivity(Intent.createChooser(emailIntent, emailSelectorText))
                     }
                 ),
                 MenuItem(
                     title = stringResource(id = R.string.setting_item_terms),
                     trailingIcon = R.drawable.ic_next_24,
                     onClick = {
-                        if (contactIntent.resolveActivity(context.packageManager) != null) {
+                        if (termPageIntent.resolveActivity(context.packageManager) != null) {
                             context.startActivity(termPageIntent)
                         }
                     }
@@ -148,7 +146,7 @@ private fun SettingScreenContent(
                     title = stringResource(id = R.string.setting_item_privacy),
                     trailingIcon = R.drawable.ic_next_24,
                     onClick = {
-                        if (contactIntent.resolveActivity(context.packageManager) != null) {
+                        if (privacyPageIntent.resolveActivity(context.packageManager) != null) {
                             context.startActivity(privacyPageIntent)
                         }
                     }


### PR DESCRIPTION
* 더보기 화면의 메뉴들에 대한 클릭 이벤트 구현
* 이메일 -> implicit intent를 사용하여 이메일 앱으로 이동할 수 있도록 구현
  * action : Intent.ACTION_SEND, data mimetype : "text/plain"
* 이용약관 및 개인정보 처리방침 -> url를 uri로 parse하여 웹 페이지로 이동하도록 구현
  * action : Intent_ACTION_VIEW