### PR TITLE
👽🚸 Feat: add a field for default image on request body and improve ux by refreshing setting screen only when profile is updated

### DIFF
--- a/core/common/src/main/java/com/sowhat/common/model/FormState.kt
+++ b/core/common/src/main/java/com/sowhat/common/model/FormState.kt
@@ -21,6 +21,7 @@ data class UpdateFormState(
     val isProfileChanged: Boolean = false,
     val isNameChanged: Boolean = false,
     val isDefault: Boolean = false,
+    val initialImageUrl: String = "",
     val newImageUri: Uri? = null,
     val isPopupMenuVisible: Boolean = false,
     val profileImage: MultipartBody.Part? = null,

--- a/core/common/src/main/java/com/sowhat/common/model/UiEvents.kt
+++ b/core/common/src/main/java/com/sowhat/common/model/UiEvents.kt
@@ -41,6 +41,7 @@ sealed class SignOutEvent {
 }
 
 sealed class UpdateFormEvent {
+    data class InitialProfileUpdated(val imageUrl: String?) : UpdateFormEvent()
     data class ProfileChanged(val image: MultipartBody.Part?) : UpdateFormEvent()
     data class ProfileUriChanged(val uri: Uri?) : UpdateFormEvent()
     data class IsProfileChanged(val isChanged: Boolean) : UpdateFormEvent()

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/component/ProfileImage.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/component/ProfileImage.kt
@@ -1,5 +1,6 @@
 package com.sowhat.designsystem.component
 
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -70,6 +71,7 @@ fun ProfileImage(
                     .clip(shape = JustSayItTheme.Shapes.circle)
                     .fillMaxSize()
                     .rippleClickable {
+                        Log.i("ProfileImage", "ProfileImageUri: ${profileUri}")
                         if (profileUri == null) onChooseClick() else onMenuShowChange(!isMenuVisible)
                     },
                 backgroundColor = badgeBackgroundColor,

--- a/user/user-data/src/main/java/com/sowhat/user_data/remote/UserApi.kt
+++ b/user/user-data/src/main/java/com/sowhat/user_data/remote/UserApi.kt
@@ -26,7 +26,7 @@ interface UserApi {
         @Header("Authorization") accessToken: String?,
         @Path("member-id") memberId: Long,
         @Part("updateProfile") profile: RequestBody,
-        @Part("profileImg") profileImage: MultipartBody.Part?,
+        @Part profileImage: MultipartBody.Part?,
     ): ResponseBody<Unit?>
 
     @POST("/members/quit/{member-id}")

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/common/UpdateRequest.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/common/UpdateRequest.kt
@@ -7,4 +7,8 @@ import kotlinx.serialization.Serializable
 data class UpdateRequest(
     @SerialName("nickname")
     val nickname: String,
+    @SerialName("profileImg")
+    val initialImageUrl: String,
+    @SerialName("defaultProfileImg")
+    val defaultProfileImg: Boolean
 )

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/edit/UpdateScreen.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/edit/UpdateScreen.kt
@@ -68,6 +68,9 @@ fun UpdateRoute(
     }
     
     LaunchedEffect(key1 = uiState.data?.profileInfo) {
+        updateViewModel.onEvent(UpdateFormEvent.InitialProfileUpdated(
+            uiState.data?.profileInfo?.profileImg
+        ))
         updateViewModel.onEvent(UpdateFormEvent.ProfileUriChanged(
             Uri.parse(uiState.data?.profileInfo?.profileImg ?: return@LaunchedEffect)
                 ?: null

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/edit/UpdateViewModel.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/edit/UpdateViewModel.kt
@@ -72,13 +72,16 @@ class UpdateViewModel @Inject constructor(
             is UpdateFormEvent.IsNameChanged -> {
                 formState = formState.copy(isNameChanged = event.isNameChanged)
             }
-
             is UpdateFormEvent.IsProfileChanged -> {
                 formState = formState.copy(isProfileChanged = event.isChanged)
             }
-
             is UpdateFormEvent.NicknamePostDataChanged -> {
                 formState = formState.copy(nicknamePostData = event.postData)
+            }
+            is UpdateFormEvent.InitialProfileUpdated -> {
+                event.imageUrl?.let {
+                    formState = formState.copy(initialImageUrl = it)
+                }
             }
         }
 
@@ -88,7 +91,7 @@ class UpdateViewModel @Inject constructor(
     fun updateUserInfo() {
         viewModelScope.launch {
             _updateInfoUiState.value = _updateInfoUiState.value.copy(isLoading = true)
-            if (!isFormValid) {
+            if (!isValid) {
                 _updateInfoUiState.value = _updateInfoUiState.value.copy(
                     isLoading = false,
                     data = null
@@ -98,7 +101,9 @@ class UpdateViewModel @Inject constructor(
             }
 
             val requestBody = UpdateRequest(
-                nickname = formState.nickname,
+                nickname = formState.nicknamePostData,
+                initialImageUrl = formState.initialImageUrl,
+                defaultProfileImg = formState.isDefault
             )
 
             Log.i("UserConfigScreen", requestBody.toString())

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/navigation/UserNavigation.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/navigation/UserNavigation.kt
@@ -29,7 +29,13 @@ fun NavGraphBuilder.settingScreen(
         popEnterTransition = null,
         popExitTransition = null
     ) {
-        SettingRoute(appNavController = appNavController)
+        SettingRoute(
+            appNavController = appNavController,
+            isUpdated = appNavController
+                .currentBackStackEntry
+                ?.savedStateHandle
+                ?.getStateFlow("isUpdated", false)
+        )
     }
 }
 
@@ -48,6 +54,11 @@ fun NavGraphBuilder.userInfoUpdateScreen(
 }
 
 fun NavController.navigateUpToSetting() {
+    // 백스택에서 현재 화면 이전, 즉 여기서는 설정 화면을 의미함. 이전 화면에 값을 저장하고자 하므로,
+    // current가 아닌 previousBackStackEntry의 savedStateHandle 사용
+    this.previousBackStackEntry
+        ?.savedStateHandle
+        ?.set("isUpdated", true)
     this.popBackStack()
 }
 

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/setting/SettingScreen.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/setting/SettingScreen.kt
@@ -2,6 +2,7 @@ package com.sowhat.user_presentation.setting
 
 import android.content.Intent
 import android.net.Uri
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -15,6 +16,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Divider
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -38,15 +40,24 @@ import com.sowhat.user_presentation.component.Menu
 import com.sowhat.user_presentation.component.UserProfile
 import com.sowhat.user_presentation.navigation.navigateToSignOut
 import com.sowhat.user_presentation.navigation.navigateToUpdate
+import kotlinx.coroutines.flow.StateFlow
 
 @Composable
 fun SettingRoute(
     viewModel: SettingViewModel = hiltViewModel(),
-    appNavController: NavHostController
+    appNavController: NavHostController,
+    isUpdated: StateFlow<Boolean>?
 ) {
-//    LaunchWhenCreated {
-//        viewModel.getUserInfo()
-//    }
+    LaunchedEffect(key1 = isUpdated) {
+        Log.i("SettingScreen", "isUpdated : ${isUpdated?.value}")
+        if (isUpdated?.value == true) {
+            viewModel.getUserInfo()
+            // 사용한 변수 제거
+            appNavController.currentBackStackEntry
+                ?.savedStateHandle
+                ?.remove<Boolean>("isUpdated")
+        }
+    }
 
     SettingScreen(
         uiState = viewModel.uiState.collectAsState().value,

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/setting/SettingViewModel.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/setting/SettingViewModel.kt
@@ -24,7 +24,7 @@ class SettingViewModel @Inject constructor(
         getUserInfo()
     }
 
-    private fun getUserInfo() {
+    fun getUserInfo() {
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isLoading = true)
 


### PR DESCRIPTION
* 프로필 수정 request body에 기본 이미지를 사용하는지 여부에 대한 boolean 필드를 추가
* 프로필 수정이 되었을 때에만 설정 화면으로 돌아왔을 때 새로고침되도록 함으로써 사용자 경험 향상
* 구현 방법 : navigation의 savedStateHandle을 활용
  * 전제조건 : 두 화면이 같은 NavHost, NavController를 공유하고 있어야 한다.
  * 프로필 수정의 화면 이동 경로 : 설정 화면 --(프로필 수정 버튼)--> 수정 화면 --(수정 완료 버튼)--> 설정 화면
  * 수정 화면에서 이전 화면으로 돌아가도록 하는 NavController의 확장함수 구현. 이 때, 수정 화면의 전 화면은 설정화면인 만큼, 설정화면으로 데이터를 전달하기 위해서는 NavController의 "previousBackStackEntry"를 활용함으로써 전 화면인 설정 화면에 접근. -> backStackEntry 객체의 경우, SavedStateHandle 객체를 제공함 -> 원하는 값을 세팅한다.(여기서는 isUpdated라는 boolean 변수를 두어, true를 이전 화면으로 전달하도록 하였다.)
  * 그리고 이전 화면인 설정 화면으로 돌아왔을 때는, 설정 화면으로 넘어온 데이터를 사용하기 위하여 NavController의 "currentBackstackEntry"를 활용함으로써 본인의 화면의 SavedStateHandle에 접근한다. 그리고 이전 화면으로부터 얻어온 값을 StateFlow 형태로 활용한다.
  * 마지막으로, 스크린 단에서 해당 flow 값을 활용한 후 더 이상 같은 값이 넘어오지 않도록 savedStateHandle의 해당 키의 값을 remove하는 작업을 잊지 않고 진행해야 한다. 그렇지 않으면 계속 isUpdated라는 Boolean 값이 계속 true로 넘어와 업데이트되지 않았음에도 다른 화면에서 넘어왔을 때 계속 새로고침이 일어나는 이슈가 발생한다.
 
* 코드
```
fun NavController.navigateUpToSetting() {
    // 백스택에서 현재 화면 이전, 즉 여기서는 설정 화면을 의미함. 이전 화면에 값을 저장하고자 하므로,
    // current가 아닌 previousBackStackEntry의 savedStateHandle 사용
    this.previousBackStackEntry
        ?.savedStateHandle
        ?.set("isUpdated", true)
    this.popBackStack()
}
```
```
fun NavGraphBuilder.settingScreen(
    appNavController: NavHostController
) {
    composable(
        route = SETTING,
        enterTransition = {
            EnterTransition.None
        },
        exitTransition = {
            ExitTransition.None
        },
        popEnterTransition = null,
        popExitTransition = null
    ) {
        SettingRoute(
            appNavController = appNavController,
            isUpdated = appNavController
                .currentBackStackEntry
                ?.savedStateHandle
                ?.getStateFlow("isUpdated", false)
        )
    }
}
```
```
@Composable
fun SettingRoute(
    viewModel: SettingViewModel = hiltViewModel(),
    appNavController: NavHostController,
    isUpdated: StateFlow<Boolean>?
) {
    LaunchedEffect(key1 = isUpdated) {
        Log.i("SettingScreen", "isUpdated : ${isUpdated?.value}")
        if (isUpdated?.value == true) {
            viewModel.getUserInfo()
            // 사용한 변수 제거
            appNavController.currentBackStackEntry
                ?.savedStateHandle
                ?.remove<Boolean>("isUpdated")
        }
    }

    SettingScreen(
        uiState = viewModel.uiState.collectAsState().value,
        appNavController = appNavController
    )
}
```