### PR TITLE
✨ Feat: add feed editing function

### DIFF
--- a/app/src/main/java/com/sowhat/justsayit/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/sowhat/justsayit/navigation/AppNavHost.kt
@@ -11,6 +11,7 @@ import com.sowhat.authentication_presentation.navigation.splashScreen
 import com.sowhat.authentication_presentation.navigation.userConfigScreen
 import com.sowhat.common.model.FCMData
 import com.sowhat.common.navigation.SPLASH
+import com.sowhat.post_presentation.navigation.editFeedScreen
 import com.sowhat.post_presentation.navigation.postScreen
 import com.sowhat.user_presentation.navigation.signOutScreen
 import com.sowhat.user_presentation.navigation.userInfoUpdateScreen
@@ -28,6 +29,7 @@ fun AppNavHost(
         userInfoUpdateScreen(appNavController = navController)
         mainScreen(appNavController = navController, snackbarHostState = snackbarHostState)
         postScreen(appNavController = navController)
+        editFeedScreen(appNavController = navController)
         userInfoUpdateScreen(appNavController = navController)
         signOutScreen(appNavController = navController)
     }

--- a/core/common/src/main/java/com/sowhat/common/navigation/Route.kt
+++ b/core/common/src/main/java/com/sowhat/common/navigation/Route.kt
@@ -13,6 +13,7 @@ const val HOME = "home"
 const val MY = "my"
 
 const val POST = "post"
+const val FEED_EDIT = "feed_edit"
 
 const val NOTIFICATION = "notification"
 

--- a/core/database/schemas/com.sowhat.database.FeedDatabase/6.json
+++ b/core/database/schemas/com.sowhat.database.FeedDatabase/6.json
@@ -1,7 +1,7 @@
 {
   "formatVersion": 1,
   "database": {
-    "version": 5,
+    "version": 6,
     "identityHash": "a9bdb6b30552b981221b0d515533b80a",
     "entities": [
       {

--- a/core/database/src/main/java/com/sowhat/database/entity/EntireFeedEntity.kt
+++ b/core/database/src/main/java/com/sowhat/database/entity/EntireFeedEntity.kt
@@ -25,6 +25,7 @@ data class EntireFeedEntity(
     val profileImg: String,
     val bodyText: String,
     val photo: List<String>,
+    val photoId: List<Long>?,
     val writerEmotion: String,
     val isAnonymous: Boolean,
     val isModified: Boolean,

--- a/core/database/src/main/java/com/sowhat/database/entity/MyFeedEntity.kt
+++ b/core/database/src/main/java/com/sowhat/database/entity/MyFeedEntity.kt
@@ -25,6 +25,7 @@ data class MyFeedEntity(
     val profileImg: String,
     val bodyText: String,
     val photo: List<String>,
+    val photoId: List<Long>?,
     val writerEmotion: String,
     val isAnonymous: Boolean,
     val isModified: Boolean,

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/common/MoodItem.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/common/MoodItem.kt
@@ -1,10 +1,12 @@
 package com.sowhat.designsystem.common
 
+import android.os.Parcelable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.graphics.Color
 import com.sowhat.designsystem.R
 import com.sowhat.designsystem.theme.JustSayItTheme
+import kotlinx.parcelize.Parcelize
 
 data class MoodItem(
     val drawable: Int,

--- a/core/designsystem/src/main/res/values/string.xml
+++ b/core/designsystem/src/main/res/values/string.xml
@@ -38,6 +38,7 @@
 
     <string name="button_start">시작하기</string>
     <string name="button_post">게시하기</string>
+    <string name="button_edit">수정하기</string>
     <string name="button_feeling_submit">감정 제출</string>
 
     <string name="dropdown_upload_image">사진 업로드하기</string>
@@ -54,6 +55,8 @@
     <string name="dialog_subtitle_posting">그만 작성하기를 누르면\n작성중인 글은 저장되지 않아요.</string>
     <string name="dialog_button_continue">계속 작성하기</string>
     <string name="dialog_button_stop">그만 작성하기</string>
+    <string name="dialog_title_editing">수정중인 글이 있어요.</string>
+    <string name="dialog_subtitle_editing">그만 수정하기를 누르면\n수정중인 글은 저장되지 않아요.</string>
     <string name="dialog_title_sign_out">로그아웃</string>
     <string name="dialog_subtitle_sign_out">로그아웃 하시겠어요?</string>
     <string name="dialog_title_withdraw">탈퇴하기</string>

--- a/core/designsystem/src/main/res/values/string.xml
+++ b/core/designsystem/src/main/res/values/string.xml
@@ -46,7 +46,7 @@
 
     <string name="error_server">서버 에러</string>
 
-    <string name="appbar_post">게시글 쓰기</string>
+    <string name="appbar_post">글 쓰기</string>
     <string name="appbar_notification">알림</string>
 
     <string name="notification_event_channel">event_channel</string>

--- a/core/di/src/main/java/com/sowhat/di/use_case/PostDomainModule.kt
+++ b/core/di/src/main/java/com/sowhat/di/use_case/PostDomainModule.kt
@@ -5,6 +5,7 @@ import com.sowhat.authentication_domain.use_case.PostNewMemberUseCase
 import com.sowhat.database.FeedDatabase
 import com.sowhat.datastore.AuthDataRepository
 import com.sowhat.post_domain.repository.PostRepository
+import com.sowhat.post_domain.use_case.EditPostUseCase
 import com.sowhat.post_domain.use_case.GetFeedDataUseCase
 import com.sowhat.post_domain.use_case.SubmitPostUseCase
 import com.sowhat.post_domain.use_case.ValidateCurrentMoodUseCase
@@ -27,6 +28,14 @@ object PostDomainModule {
         authDataRepository: AuthDataRepository
     ): SubmitPostUseCase =
         SubmitPostUseCase(repository, authDataRepository)
+
+    @Provides
+    @Singleton
+    fun provideEditPostUseCase(
+        repository: PostRepository,
+        authDataRepository: AuthDataRepository
+    ): EditPostUseCase =
+        EditPostUseCase(repository, authDataRepository)
 
     @Provides
     @Singleton

--- a/core/di/src/main/java/com/sowhat/di/use_case/PostDomainModule.kt
+++ b/core/di/src/main/java/com/sowhat/di/use_case/PostDomainModule.kt
@@ -2,8 +2,10 @@ package com.sowhat.di.use_case
 
 import com.sowhat.authentication_domain.repository.AuthRepository
 import com.sowhat.authentication_domain.use_case.PostNewMemberUseCase
+import com.sowhat.database.FeedDatabase
 import com.sowhat.datastore.AuthDataRepository
 import com.sowhat.post_domain.repository.PostRepository
+import com.sowhat.post_domain.use_case.GetFeedDataUseCase
 import com.sowhat.post_domain.use_case.SubmitPostUseCase
 import com.sowhat.post_domain.use_case.ValidateCurrentMoodUseCase
 import com.sowhat.post_domain.use_case.ValidatePostImagesUseCase
@@ -41,4 +43,10 @@ object PostDomainModule {
     @Provides
     @Singleton
     fun provideValidateSympathyUseCase(): ValidateSympathyUseCase = ValidateSympathyUseCase()
+
+    @Provides
+    @Singleton
+    fun provideGetFeedDataUseCase(
+        feedDatabase: FeedDatabase
+    ): GetFeedDataUseCase = GetFeedDataUseCase(feedDatabase = feedDatabase)
 }

--- a/feed/feed-data/src/main/java/com/sowhat/feed_data/repository/EntireFeedRepositoryImpl.kt
+++ b/feed/feed-data/src/main/java/com/sowhat/feed_data/repository/EntireFeedRepositoryImpl.kt
@@ -262,6 +262,7 @@ class EntireFeedRepositoryImpl(
                 profileImg = feed.profileInfo.profileImg,
                 bodyText = feed.storyMainContent.bodyText,
                 photo = feed.storyMainContent.photo.map { it.photoUrl },
+                photoId = feed.storyMainContent.photo.map { it.photoId },
                 writerEmotion = feed.storyMainContent.writerEmotion,
                 isAnonymous = feed.storyMetaInfo.isAnonymous,
                 isModified = feed.storyMetaInfo.isModified,

--- a/feed/feed-presentation/src/main/java/com/sowhat/feed_presentation/feeds/FeedScreen.kt
+++ b/feed/feed-presentation/src/main/java/com/sowhat/feed_presentation/feeds/FeedScreen.kt
@@ -57,6 +57,7 @@ import com.sowhat.designsystem.component.PopupMenuItem
 import com.sowhat.designsystem.component.SelectionAlertDialog
 import com.sowhat.feed_presentation.common.PostResult
 import com.sowhat.feed_presentation.component.Feed
+import com.sowhat.feed_presentation.navigation.navigateToEditScreen
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.launch
 
@@ -304,6 +305,7 @@ fun FeedScreen(
                     }
 
                     Feed(
+                        navController = navController,
                         feedItem = feed,
                         onFeedEvent = onFeedEvent,
                         selectedSympathy = selectedSympathy,
@@ -387,6 +389,7 @@ fun FeedScreen(
 
 @Composable
 private fun Feed(
+    navController: NavController,
     feedItem: EntireFeedEntity,
     onFeedEvent: (FeedEvent) -> Unit,
     selectedSympathy: MoodItem?,
@@ -436,7 +439,7 @@ private fun Feed(
             onItemClick = {
                 val feedId = feedItem.storyId
                 onFeedEvent(FeedEvent.TargetIdChanged(feedId))
-                // TODO 수정 화면으로 이동
+                navController.navigateToEditScreen(feedId)
             },
             postData = null,
             contentColor = JustSayItTheme.Colors.mainTypo,

--- a/feed/feed-presentation/src/main/java/com/sowhat/feed_presentation/navigation/FeedNavigation.kt
+++ b/feed/feed-presentation/src/main/java/com/sowhat/feed_presentation/navigation/FeedNavigation.kt
@@ -3,9 +3,11 @@ package com.sowhat.feed_presentation.navigation
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.material3.SnackbarHostState
+import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
+import com.sowhat.common.navigation.FEED_EDIT
 import com.sowhat.common.navigation.HOME
 import com.sowhat.feed_presentation.feeds.FeedRoute
 
@@ -28,5 +30,11 @@ fun NavGraphBuilder.homeScreen(
             navController = appNavController,
             snackbarHostState = snackbarHostState
         )
+    }
+}
+
+fun NavController.navigateToEditScreen(feedId: Long) {
+    this.navigate("$FEED_EDIT/$HOME/$feedId") {
+        launchSingleTop = true
     }
 }

--- a/post/post-data/src/main/java/com/sowhat/post_data/remote/PostApi.kt
+++ b/post/post-data/src/main/java/com/sowhat/post_data/remote/PostApi.kt
@@ -5,6 +5,7 @@ import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import retrofit2.http.Header
 import retrofit2.http.Multipart
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Part
 
@@ -19,7 +20,7 @@ interface PostApi {
     ): ResponseBody<Unit?>
 
     @Multipart
-    @POST("/stories/edit")
+    @PATCH("/stories/edit")
     suspend fun editPost(
         @Header("Authorization") accessToken: String,
         @Part("storyInfo") storyInfo: RequestBody,

--- a/post/post-data/src/main/java/com/sowhat/post_data/remote/PostApi.kt
+++ b/post/post-data/src/main/java/com/sowhat/post_data/remote/PostApi.kt
@@ -17,4 +17,12 @@ interface PostApi {
         @Part("storyInfo") storyInfo: RequestBody,
         @Part storyImg: List<MultipartBody.Part?>?
     ): ResponseBody<Unit?>
+
+    @Multipart
+    @POST("/stories/edit")
+    suspend fun editPost(
+        @Header("Authorization") accessToken: String,
+        @Part("storyInfo") storyInfo: RequestBody,
+        @Part newImg: List<MultipartBody.Part?>?
+    ): ResponseBody<Unit?>
 }

--- a/post/post-data/src/main/java/com/sowhat/post_data/repository/PostRepositoryImpl.kt
+++ b/post/post-data/src/main/java/com/sowhat/post_data/repository/PostRepositoryImpl.kt
@@ -58,4 +58,44 @@ class PostRepositoryImpl(
             message = postResult.message
         )
     }
+
+    override suspend fun editPost(
+        accessToken: String,
+        storyInfo: RequestBody,
+        newImg: List<MultipartBody.Part?>?
+    ): Resource<Unit?> = try {
+        getEditPostResource(
+            accessToken = accessToken,
+            storyInfo = storyInfo,
+            newImg = newImg
+        )
+    } catch (e: HttpException) {
+        getHttpErrorResource(e)
+    } catch (e: IOException) {
+        getIOErrorResource(e)
+    }
+
+    private suspend fun getEditPostResource(
+        accessToken: String,
+        storyInfo: RequestBody,
+        newImg: List<MultipartBody.Part?>?
+    ): Resource<Unit?> {
+        val postResult = postApi.editPost(
+            accessToken = accessToken,
+            storyInfo = storyInfo,
+            newImg = newImg
+        )
+
+        return if (postResult.isSuccess) {
+            Resource.Success(
+                data = null,
+                code = postResult.code,
+                message = postResult.message
+            )
+        } else Resource.Error(
+            data = null,
+            code = postResult.code,
+            message = postResult.message
+        )
+    }
 }

--- a/post/post-domain/build.gradle.kts
+++ b/post/post-domain/build.gradle.kts
@@ -16,6 +16,7 @@ android {
 dependencies {
     implementation(project(":core:network"))
     implementation(project(":core:datastore"))
+    implementation(project(":core:database"))
     implementation(project(":core:common"))
     implementation(project(":core:designsystem"))
 

--- a/post/post-domain/src/main/java/com/sowhat/post_domain/repository/PostRepository.kt
+++ b/post/post-domain/src/main/java/com/sowhat/post_domain/repository/PostRepository.kt
@@ -12,4 +12,11 @@ interface PostRepository {
         storyInfo: RequestBody,
         storyImg: List<MultipartBody.Part?>?
     ): Resource<Unit?>
+
+    suspend fun editPost(
+        accessToken: String,
+//        memberId: Long,
+        storyInfo: RequestBody,
+        newImg: List<MultipartBody.Part?>?
+    ): Resource<Unit?>
 }

--- a/post/post-domain/src/main/java/com/sowhat/post_domain/use_case/EditPostUseCase.kt
+++ b/post/post-domain/src/main/java/com/sowhat/post_domain/use_case/EditPostUseCase.kt
@@ -1,0 +1,25 @@
+package com.sowhat.post_domain.use_case
+
+import com.sowhat.common.model.Resource
+import com.sowhat.datastore.AuthDataRepository
+import com.sowhat.post_domain.repository.PostRepository
+import kotlinx.coroutines.flow.first
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import javax.inject.Inject
+
+class EditPostUseCase @Inject constructor(
+    private val postRepository: PostRepository,
+    private val authRepository: AuthDataRepository,
+) {
+    suspend operator fun invoke(
+        storyInfo: RequestBody,
+        newImg: List<MultipartBody.Part?>?
+    ): Resource<Unit?> {
+        val authData = authRepository.authData.first()
+        val accessToken = authData.accessToken
+            ?: return Resource.Error(message = "로그인을 진행해야 게시글을 작성할 수 있습니다.")
+
+        return postRepository.editPost(accessToken, storyInfo, newImg)
+    }
+}

--- a/post/post-domain/src/main/java/com/sowhat/post_domain/use_case/GetFeedDataUseCase.kt
+++ b/post/post-domain/src/main/java/com/sowhat/post_domain/use_case/GetFeedDataUseCase.kt
@@ -1,6 +1,9 @@
 package com.sowhat.post_domain.use_case
 
+import com.sowhat.common.navigation.HOME
+import com.sowhat.common.navigation.MY
 import com.sowhat.database.FeedDatabase
+import com.sowhat.database.entity.EntireFeedEntity
 import com.sowhat.database.entity.MyFeedEntity
 import java.io.IOException
 import javax.inject.Inject
@@ -8,12 +11,44 @@ import javax.inject.Inject
 class GetFeedDataUseCase @Inject constructor(
     private val feedDatabase: FeedDatabase
 ) {
-    suspend operator fun invoke(feedId: Long): MyFeedEntity? {
+    suspend operator fun invoke(feedId: Long, from: String): MyFeedEntity? {
         return try {
-            val dao = feedDatabase.myFeedDao
-            dao.getFeedItemByFeedId(feedId)
+            when (from) {
+                HOME -> {
+                    val feedItem = feedDatabase.entireFeedDao.getFeedItemByFeedId(feedId)
+                    getMyFeedEntity(feedItem)
+                }
+                MY -> feedDatabase.myFeedDao.getFeedItemByFeedId(feedId)
+                else -> null
+            }
         } catch (e: Exception) {
             null
         }
     }
+
+    private fun getMyFeedEntity(feedItem: EntireFeedEntity) = MyFeedEntity(
+        storyUUID = feedItem.storyUUID,
+        storyId = feedItem.storyId,
+        createdAt = feedItem.createdAt,
+        updatedAt = feedItem.updatedAt,
+        writerId = feedItem.writerId,
+        totalCount = feedItem.totalCount,
+        happinessCount = feedItem.happinessCount,
+        sadnessCount = feedItem.sadnessCount,
+        surprisedCount = feedItem.surprisedCount,
+        angryCount = feedItem.angryCount,
+        isHappinessSelected = feedItem.isHappinessSelected,
+        isSadnessSelected = feedItem.isSadnessSelected,
+        isSurprisedSelected = feedItem.isSurprisedSelected,
+        isAngrySelected = feedItem.isAngrySelected,
+        nickname = feedItem.nickname,
+        profileImg = feedItem.profileImg,
+        bodyText = feedItem.bodyText,
+        photo = feedItem.photo,
+        photoId = feedItem.photoId,
+        writerEmotion = feedItem.writerEmotion,
+        isAnonymous = feedItem.isAnonymous,
+        isModified = feedItem.isModified,
+        isOpened = feedItem.isOpened
+    )
 }

--- a/post/post-domain/src/main/java/com/sowhat/post_domain/use_case/GetFeedDataUseCase.kt
+++ b/post/post-domain/src/main/java/com/sowhat/post_domain/use_case/GetFeedDataUseCase.kt
@@ -1,0 +1,19 @@
+package com.sowhat.post_domain.use_case
+
+import com.sowhat.database.FeedDatabase
+import com.sowhat.database.entity.MyFeedEntity
+import java.io.IOException
+import javax.inject.Inject
+
+class GetFeedDataUseCase @Inject constructor(
+    private val feedDatabase: FeedDatabase
+) {
+    suspend operator fun invoke(feedId: Long): MyFeedEntity? {
+        return try {
+            val dao = feedDatabase.myFeedDao
+            dao.getFeedItemByFeedId(feedId)
+        } catch (e: Exception) {
+            null
+        }
+    }
+}

--- a/post/post-presentation/build.gradle.kts
+++ b/post/post-presentation/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("com.sowhat.justsayit.application.common")
     id("com.sowhat.justsayit.application.oauth")
     id("com.sowhat.justsayit.application.hilt")
+    id("kotlin-parcelize")
 }
 
 android {
@@ -18,6 +19,7 @@ android {
 dependencies {
     implementation(project(":core:designsystem"))
     implementation(project(":core:common"))
+    implementation(project(":core:database"))
     implementation(project(":core:di"))
     implementation(project(":core:network"))
     implementation(project(":post:post-domain"))

--- a/post/post-presentation/src/main/java/com/sowhat/post_presentation/common/EditRequest.kt
+++ b/post/post-presentation/src/main/java/com/sowhat/post_presentation/common/EditRequest.kt
@@ -1,0 +1,23 @@
+package com.sowhat.post_presentation.common
+
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class EditRequest(
+    @SerialName("anonymous")
+    val anonymous: Boolean,
+    @SerialName("content")
+    val content: String,
+    @SerialName("emotion")
+    val emotion: String,
+    @SerialName("emotionOfEmpathy")
+    val emotionOfEmpathy: List<String>,
+    @SerialName("opened")
+    val opened: Boolean,
+    @SerialName("removedPhoto")
+    val removedPhoto: List<Long>,
+    @SerialName("storyId")
+    val storyId: Long
+)

--- a/post/post-presentation/src/main/java/com/sowhat/post_presentation/common/Events.kt
+++ b/post/post-presentation/src/main/java/com/sowhat/post_presentation/common/Events.kt
@@ -13,3 +13,14 @@ sealed class PostFormEvent {
     data class SympathyItemsChanged(val sympathyItems: List<MoodItem>) : PostFormEvent()
     data class DialogVisibilityChanged(val isVisible: Boolean) : PostFormEvent()
 }
+
+sealed class EditFormEvent {
+    data class DeletedUrlIdAdded(val urlIds: List<Long>) : EditFormEvent()
+    data class CurrentMoodChanged(val mood: MoodItem) : EditFormEvent()
+    data class ImageListUpdated(val images: List<Uri>?) : EditFormEvent()
+    data class PostTextChanged(val text: String) : EditFormEvent()
+    data class OpenChanged(val open: Boolean) : EditFormEvent()
+    data class AnonymousChanged(val anonymous: Boolean) : EditFormEvent()
+    data class SympathyItemsChanged(val sympathyItems: List<MoodItem>) : EditFormEvent()
+    data class DialogVisibilityChanged(val isVisible: Boolean) : EditFormEvent()
+}

--- a/post/post-presentation/src/main/java/com/sowhat/post_presentation/common/States.kt
+++ b/post/post-presentation/src/main/java/com/sowhat/post_presentation/common/States.kt
@@ -20,9 +20,10 @@ data class PostFormState(
 )
 
 data class EditFormState(
-    val isChanged: Boolean = false,
+    val storyId: Long? = null,
     val existingUrl: List<String> = emptyList(),
-    val deletedUrl: MutableList<String> = emptyList<String>().toMutableList(),
+    val existingUrlId: List<Long> = emptyList(),
+    val deletedUrlId: List<Long> = emptyList(),
     val currentMood: MoodItem? = null,
     val isCurrentMoodValid: Boolean = false,
     val postText: String = "",

--- a/post/post-presentation/src/main/java/com/sowhat/post_presentation/common/States.kt
+++ b/post/post-presentation/src/main/java/com/sowhat/post_presentation/common/States.kt
@@ -1,9 +1,28 @@
 package com.sowhat.post_presentation.common
 
 import android.net.Uri
+import android.os.Parcelable
 import com.sowhat.designsystem.common.MoodItem
+import kotlinx.parcelize.Parcelize
 
 data class PostFormState(
+    val currentMood: MoodItem? = null,
+    val isCurrentMoodValid: Boolean = false,
+    val postText: String = "",
+    val isPostTextValid: Boolean = false,
+    val images: List<Uri> = emptyList(),
+    val isImageListValid: Boolean = true,
+    val isOpened: Boolean = false,
+    val isAnonymous: Boolean = false,
+    val sympathyMoodItems: List<MoodItem> = emptyList(),
+    val isSympathyMoodItemsValid: Boolean = true,
+    val isDialogVisible: Boolean = false,
+)
+
+data class EditFormState(
+    val isChanged: Boolean = false,
+    val existingUrl: List<String> = emptyList(),
+    val deletedUrl: MutableList<String> = emptyList<String>().toMutableList(),
     val currentMood: MoodItem? = null,
     val isCurrentMoodValid: Boolean = false,
     val postText: String = "",

--- a/post/post-presentation/src/main/java/com/sowhat/post_presentation/common/States.kt
+++ b/post/post-presentation/src/main/java/com/sowhat/post_presentation/common/States.kt
@@ -20,6 +20,7 @@ data class PostFormState(
 )
 
 data class EditFormState(
+    val isChanged: Boolean = false,
     val storyId: Long? = null,
     val existingUrl: List<String> = emptyList(),
     val existingUrlId: List<Long> = emptyList(),

--- a/post/post-presentation/src/main/java/com/sowhat/post_presentation/edit/EditScreen.kt
+++ b/post/post-presentation/src/main/java/com/sowhat/post_presentation/edit/EditScreen.kt
@@ -2,6 +2,8 @@ package com.sowhat.post_presentation.edit
 
 import android.util.Log
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Spacer
@@ -22,7 +24,9 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
+import com.sowhat.common.model.PostingEvent
 import com.sowhat.common.model.UiState
+import com.sowhat.common.util.ObserveEvents
 import com.sowhat.designsystem.R
 import com.sowhat.designsystem.common.MoodItem
 import com.sowhat.designsystem.common.addFocusCleaner
@@ -32,6 +36,7 @@ import com.sowhat.designsystem.component.AppBar
 import com.sowhat.designsystem.component.CenteredCircularProgress
 import com.sowhat.designsystem.component.DefaultButtonFull
 import com.sowhat.designsystem.theme.JustSayItTheme
+import com.sowhat.post_presentation.common.EditFormEvent
 import com.sowhat.post_presentation.common.EditFormState
 import com.sowhat.post_presentation.common.PostFormEvent
 import com.sowhat.post_presentation.common.PostFormState
@@ -47,6 +52,7 @@ import com.sowhat.post_presentation.navigation.navigateBack
 fun EditRoute(
     navController: NavController,
     feedId: Long,
+    from: String,
     viewModel: EditViewModel = hiltViewModel()
 ) {
     val formState = viewModel.formState.collectAsState().value
@@ -57,15 +63,234 @@ fun EditRoute(
     val availableImageCount = 4
 
     LaunchedEffect(key1 = true) {
-        viewModel.getFeedData(feedId, moodListItems)
+        viewModel.getFeedData(feedId, moodListItems, from)
     }
 
-//    EditScreen(
-//        navController = navController,
-//        formState = formState,
-//        isValid = viewModel.isFormValid,
-//        uiState = uiState,
-//        moods = moods,
-//        onAddImage =
-//    )
+    ObserveEvents(flow = viewModel.postingEvent) { uiEvent ->
+        when (uiEvent) {
+            is PostingEvent.NavigateUp -> {
+                Log.i("PostScreen", "navigate to main")
+                navController.navigateBack()
+            }
+            is PostingEvent.Error -> {
+                Log.i("PostScreen", "error ${uiEvent.message}")
+            }
+        }
+    }
+
+    val imagePicker = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetMultipleContents(),
+        onResult = { uri ->
+            uri.let {
+                val currentImages = formState.images.toMutableList()
+                val currentSize = currentImages.size
+                val availableAddCount = availableImageCount - currentSize
+                it.forEachIndexed { index, uri ->
+                    if (index + 1 <= availableAddCount) currentImages.add(uri)
+                }
+
+                viewModel.onEvent(EditFormEvent.ImageListUpdated(currentImages))
+            }
+        }
+    )
+
+    EditScreen(
+        navController = navController,
+        isValid = viewModel.isFormValid,
+        formState = formState,
+        uiState = uiState,
+        moods = moods,
+        onAddImage = { imagePicker.launch("image/*") },
+        onEvent = viewModel::onEvent,
+        onSubmit = viewModel::submitPost
+    )
+}
+
+@Composable
+fun EditScreen(
+    navController: NavController,
+    isValid: Boolean,
+    formState: EditFormState,
+    uiState: UiState<Unit?>,
+    moods: List<MoodItem>,
+    onAddImage: () -> Unit,
+    onEvent: (EditFormEvent) -> Unit,
+    onSubmit: () -> Unit
+) {
+    val textFocusRequester = remember { FocusRequester() }
+    val focusManager = LocalFocusManager.current
+
+    BackHandler(
+        enabled = true
+    ) {
+        if (!formState.isDialogVisible) {
+            onEvent(EditFormEvent.DialogVisibilityChanged(true))
+        } else {
+            onEvent(EditFormEvent.DialogVisibilityChanged(false))
+        }
+    }
+
+    Scaffold(
+        modifier = Modifier
+            .fillMaxSize()
+            .addFocusCleaner(focusManager),
+        topBar = {
+            AppBar(
+                title = stringResource(id = R.string.appbar_post),
+                navigationIcon = R.drawable.ic_close_24,
+                actionIcon = null,
+                onNavigationIconClick = {
+                    onEvent(EditFormEvent.DialogVisibilityChanged(true))
+                }
+            )
+        },
+        bottomBar = {
+            Box(modifier = Modifier
+                .fillMaxWidth()
+                .background(JustSayItTheme.Colors.mainBackground)
+            ) {
+                DefaultButtonFull(
+                    modifier = Modifier
+                        .padding(
+                            JustSayItTheme.Spacing.spaceBase
+                        ),
+                    text = stringResource(R.string.button_edit),
+                    isActive = isValid,
+                    onClick = { onSubmit() }
+                )
+            }
+        }
+    ) { paddingValues ->
+        LazyColumn(
+            modifier = Modifier
+                .padding(paddingValues)
+                .background(JustSayItTheme.Colors.mainBackground)
+        ) {
+            item {
+                CurrentMoodSelection(
+                    subjectItem = SubjectItem(
+                        stringResource(id = com.sowhat.designsystem.R.string.title_select_mood),
+                        stringResource(id = com.sowhat.designsystem.R.string.subtitle_select_mood)
+                    ),
+                    currentMood = formState.currentMood,
+                    onChange = { changedMood ->
+                        onEvent(EditFormEvent.CurrentMoodChanged(changedMood))
+                    },
+                    moodItems = moods
+                )
+            }
+
+            item {
+                PostText(
+                    modifier = Modifier,
+                    focusRequester = textFocusRequester,
+                    subject = SubjectItem(
+                        title = stringResource(id = com.sowhat.designsystem.R.string.title_write),
+                        subTitle = stringResource(id = com.sowhat.designsystem.R.string.subtitle_write)
+                    ),
+                    placeholder = stringResource(id = com.sowhat.designsystem.R.string.placeholder_post),
+                    text = formState.postText,
+                    onTextChange = { changedText ->
+                        onEvent(EditFormEvent.PostTextChanged(changedText))
+                    },
+                    maxLength = 300
+                )
+            }
+
+            item {
+                ImageSelection(
+                    images = formState.images,
+                    onAddClick = { onAddImage() },
+                    onImagesChange = { images ->
+                        val deletedImageIds = mutableListOf<Long>()
+                        formState.existingUrl.zip(formState.existingUrlId) { url, id ->
+                            if (url !in images.map { uri -> uri.toString() }) {
+                                deletedImageIds.add(id)
+                            }
+                        }
+                        onEvent(EditFormEvent.DeletedUrlIdAdded(deletedImageIds))
+                        onEvent(EditFormEvent.ImageListUpdated(images))
+                    }
+                )
+            }
+
+            item {
+                PostToggle(
+                    subject = SubjectItem(
+                        stringResource(id = com.sowhat.designsystem.R.string.title_is_open),
+                        stringResource(
+                            id = com.sowhat.designsystem.R.string.subtitle_is_open
+                        )
+                    ),
+                    isActivated = true,
+                    isChecked = formState.isOpened,
+                    onCheckedChange = { updatedState ->
+                        onEvent(EditFormEvent.OpenChanged(updatedState))
+                    }
+                )
+            }
+
+            item {
+                PostToggle(
+                    subject = SubjectItem(
+                        stringResource(id = com.sowhat.designsystem.R.string.title_is_anonymous),
+                        stringResource(id = com.sowhat.designsystem.R.string.subtitle_is_anonymous)
+                    ),
+                    isActivated = formState.isOpened,
+                    isChecked = formState.isAnonymous,
+                    onCheckedChange = { updatedState ->
+                        onEvent(EditFormEvent.AnonymousChanged(updatedState))
+                    }
+                )
+            }
+
+            item {
+                SympathySelection(
+                    isActive = formState.isOpened,
+                    subjectItem = SubjectItem(
+                        stringResource(id = com.sowhat.designsystem.R.string.title_select_sympathy),
+                        stringResource(
+                            id = com.sowhat.designsystem.R.string.subtitle_select_sympathy
+                        )
+                    ),
+                    onClick = { changedItem ->
+                        val currentItems = formState.sympathyMoodItems.toMutableList()
+                        if (changedItem in currentItems) {
+                            currentItems.remove(changedItem)
+                        } else {
+                            currentItems.add(changedItem)
+                        }
+                        onEvent(EditFormEvent.SympathyItemsChanged(currentItems))
+                    },
+                    selectedMoods = formState.sympathyMoodItems,
+                    moodItems = moods
+                )
+            }
+
+            item {
+                Spacer(modifier = Modifier.height(JustSayItTheme.Spacing.spaceLg))
+            }
+        }
+
+        if (formState.isDialogVisible) {
+            AlertDialog(
+                title = stringResource(id = R.string.dialog_title_editing),
+                subTitle = stringResource(
+                    id = R.string.dialog_subtitle_editing
+                ),
+                buttonContent = stringResource(id = R.string.dialog_button_continue_edit) to stringResource(
+                    id = R.string.dialog_button_stop_edit
+                ),
+                onAccept = {
+                    onEvent(EditFormEvent.DialogVisibilityChanged(false))
+                    navController.navigateBack()
+                },
+                onDismiss = { onEvent(EditFormEvent.DialogVisibilityChanged(false)) }
+            )
+        }
+    }
+
+    if (uiState.isLoading) {
+        CenteredCircularProgress()
+    }
 }

--- a/post/post-presentation/src/main/java/com/sowhat/post_presentation/edit/EditScreen.kt
+++ b/post/post-presentation/src/main/java/com/sowhat/post_presentation/edit/EditScreen.kt
@@ -1,13 +1,71 @@
 package com.sowhat.post_presentation.edit
 
+import android.util.Log
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.navigation.NavController
+import com.sowhat.common.model.UiState
+import com.sowhat.designsystem.R
+import com.sowhat.designsystem.common.MoodItem
+import com.sowhat.designsystem.common.addFocusCleaner
+import com.sowhat.designsystem.common.rememberMoodItems
+import com.sowhat.designsystem.component.AlertDialog
+import com.sowhat.designsystem.component.AppBar
+import com.sowhat.designsystem.component.CenteredCircularProgress
+import com.sowhat.designsystem.component.DefaultButtonFull
+import com.sowhat.designsystem.theme.JustSayItTheme
+import com.sowhat.post_presentation.common.EditFormState
+import com.sowhat.post_presentation.common.PostFormEvent
+import com.sowhat.post_presentation.common.PostFormState
+import com.sowhat.post_presentation.common.SubjectItem
+import com.sowhat.post_presentation.component.CurrentMoodSelection
+import com.sowhat.post_presentation.component.ImageSelection
+import com.sowhat.post_presentation.component.PostText
+import com.sowhat.post_presentation.component.PostToggle
+import com.sowhat.post_presentation.component.SympathySelection
+import com.sowhat.post_presentation.navigation.navigateBack
 
 @Composable
-fun EditRoute() {
+fun EditRoute(
+    navController: NavController,
+    feedId: Long,
+    viewModel: EditViewModel = hiltViewModel()
+) {
+    val formState = viewModel.formState.collectAsState().value
+    val moodListItems = rememberMoodItems()
+    val uiState = viewModel.uiState
+    val moods = rememberMoodItems()
+    val context = LocalContext.current
+    val availableImageCount = 4
 
-}
+    LaunchedEffect(key1 = true) {
+        viewModel.getFeedData(feedId, moodListItems)
+    }
 
-@Composable
-fun EditScreen() {
-
+//    EditScreen(
+//        navController = navController,
+//        formState = formState,
+//        isValid = viewModel.isFormValid,
+//        uiState = uiState,
+//        moods = moods,
+//        onAddImage =
+//    )
 }

--- a/post/post-presentation/src/main/java/com/sowhat/post_presentation/edit/EditScreen.kt
+++ b/post/post-presentation/src/main/java/com/sowhat/post_presentation/edit/EditScreen.kt
@@ -1,0 +1,13 @@
+package com.sowhat.post_presentation.edit
+
+import androidx.compose.runtime.Composable
+
+@Composable
+fun EditRoute() {
+
+}
+
+@Composable
+fun EditScreen() {
+
+}

--- a/post/post-presentation/src/main/java/com/sowhat/post_presentation/edit/EditViewModel.kt
+++ b/post/post-presentation/src/main/java/com/sowhat/post_presentation/edit/EditViewModel.kt
@@ -1,11 +1,130 @@
 package com.sowhat.post_presentation.edit
 
+import android.net.Uri
+import android.util.Log
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.sowhat.common.model.UiState
+import com.sowhat.database.entity.MyFeedEntity
+import com.sowhat.designsystem.common.Emotion
+import com.sowhat.designsystem.common.Mood
+import com.sowhat.designsystem.common.MoodItem
+import com.sowhat.post_domain.use_case.GetFeedDataUseCase
+import com.sowhat.post_presentation.common.EditFormState
+import com.sowhat.post_presentation.common.PostFormState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class EditViewModel @Inject constructor(
+    private val getFeedDataUseCase: GetFeedDataUseCase,
+    private val savedStateHandle: SavedStateHandle
+) : ViewModel() {
 
-) :ViewModel() {
+    private var _formState = MutableStateFlow(
+        EditFormState(
+            isCurrentMoodValid = true,
+            isPostTextValid = true,
+            isImageListValid = true,
+            isSympathyMoodItemsValid = true,
+        )
+    )
+    val formState = _formState.asStateFlow()
+
+    var uiState by mutableStateOf(UiState<Unit?>())
+        private set
+
+    val isFormValid by derivedStateOf {
+        formState.value.isImageListValid
+            && formState.value.isCurrentMoodValid
+            && formState.value.isPostTextValid
+            && formState.value.isSympathyMoodItemsValid
+            && formState.value.isChanged
+    }
+
+    fun getFeedData(feedId: Long, moodItems: List<MoodItem>) {
+        viewModelScope.launch {
+            getFeedDataUseCase(feedId)?.let { feedEntity ->
+                updateInitialFormState(moodItems, feedEntity)
+            } ?: Log.e(TAG, "feed data is null")
+        }
+    }
+
+    private fun updateInitialFormState(
+        moodItems: List<MoodItem>,
+        feedEntity: MyFeedEntity
+    ) {
+        _formState.update { currentForm ->
+            currentForm.copy(
+                currentMood = moodItems.find { it.postData == feedEntity.writerEmotion },
+                postText = feedEntity.bodyText,
+                images = feedEntity.photo.map {
+                    Uri.parse(it)
+                },
+                existingUrl = feedEntity.photo,
+                isOpened = feedEntity.isOpened,
+                isAnonymous = feedEntity.isAnonymous,
+                sympathyMoodItems = getCurrentSympathyItems(
+                    isHappySelected = feedEntity.isHappinessSelected,
+                    isSadSelected = feedEntity.isSadnessSelected,
+                    isSurprisedSelected = feedEntity.isSurprisedSelected,
+                    isAngrySelected = feedEntity.isAngrySelected,
+                    moodItems = moodItems
+                )
+            )
+        }
+
+        Log.i(TAG, "updateInitialFormState: form state : ${formState.value}")
+    }
+
+    private fun getCurrentSympathyItems(
+        isHappySelected: Boolean,
+        isSadSelected: Boolean,
+        isSurprisedSelected: Boolean,
+        isAngrySelected: Boolean,
+        moodItems: List<MoodItem>
+    ): List<MoodItem> {
+        val sympathyItems = mutableListOf<MoodItem>()
+
+        if (isHappySelected) {
+            moodItems.find { it.postData == Mood.HAPPY.postData }?.let {
+                sympathyItems.add(it)
+            }
+        }
+
+        if (isSadSelected) {
+            moodItems.find { it.postData == Mood.SAD.postData }?.let {
+                sympathyItems.add(it)
+            }
+        }
+
+        if (isSurprisedSelected) {
+            moodItems.find { it.postData == Mood.SURPRISED.postData }?.let {
+                sympathyItems.add(it)
+            }
+        }
+
+        if (isAngrySelected) {
+            moodItems.find { it.postData == Mood.ANGRY.postData }?.let {
+                sympathyItems.add(it)
+            }
+        }
+
+        return sympathyItems
+    }
+
+
+    companion object {
+        private const val TAG = "EditViewModel"
+        private const val EDIT_STATE = "edit_state"
+    }
 }

--- a/post/post-presentation/src/main/java/com/sowhat/post_presentation/edit/EditViewModel.kt
+++ b/post/post-presentation/src/main/java/com/sowhat/post_presentation/edit/EditViewModel.kt
@@ -1,0 +1,11 @@
+package com.sowhat.post_presentation.edit
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class EditViewModel @Inject constructor(
+
+) :ViewModel() {
+}

--- a/post/post-presentation/src/main/java/com/sowhat/post_presentation/edit/EditViewModel.kt
+++ b/post/post-presentation/src/main/java/com/sowhat/post_presentation/edit/EditViewModel.kt
@@ -9,24 +9,42 @@ import androidx.compose.runtime.setValue
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.sowhat.common.model.PostingEvent
+import com.sowhat.common.model.Resource
 import com.sowhat.common.model.UiState
 import com.sowhat.database.entity.MyFeedEntity
-import com.sowhat.designsystem.common.Emotion
 import com.sowhat.designsystem.common.Mood
 import com.sowhat.designsystem.common.MoodItem
+import com.sowhat.post_domain.use_case.EditPostUseCase
 import com.sowhat.post_domain.use_case.GetFeedDataUseCase
+import com.sowhat.post_domain.use_case.SubmitPostUseCase
+import com.sowhat.post_domain.use_case.ValidateCurrentMoodUseCase
+import com.sowhat.post_domain.use_case.ValidatePostImagesUseCase
+import com.sowhat.post_domain.use_case.ValidatePostTextUseCase
+import com.sowhat.post_domain.use_case.ValidateSympathyUseCase
+import com.sowhat.post_presentation.common.EditFormEvent
 import com.sowhat.post_presentation.common.EditFormState
-import com.sowhat.post_presentation.common.PostFormState
+import com.sowhat.post_presentation.util.MultipartConverter
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
 import javax.inject.Inject
 
 @HiltViewModel
 class EditViewModel @Inject constructor(
     private val getFeedDataUseCase: GetFeedDataUseCase,
+    private val editPostUseCase: EditPostUseCase,
+    private val validateCurrentMoodUseCase: ValidateCurrentMoodUseCase,
+    private val validatePostImagesUseCase: ValidatePostImagesUseCase,
+    private val validatePostTextUseCase: ValidatePostTextUseCase,
+    private val validateSympathyUseCase: ValidateSympathyUseCase,
+    private val multipartConverter: MultipartConverter,
     private val savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
@@ -40,20 +58,31 @@ class EditViewModel @Inject constructor(
     )
     val formState = _formState.asStateFlow()
 
+    private var isChanged = MutableStateFlow(false)
+
     var uiState by mutableStateOf(UiState<Unit?>())
         private set
+
+    private val postingEventChannel = Channel<PostingEvent>()
+    val postingEvent = postingEventChannel.receiveAsFlow()
 
     val isFormValid by derivedStateOf {
         formState.value.isImageListValid
             && formState.value.isCurrentMoodValid
             && formState.value.isPostTextValid
             && formState.value.isSympathyMoodItemsValid
-            && formState.value.isChanged
+            && isChanged.value
     }
 
-    fun getFeedData(feedId: Long, moodItems: List<MoodItem>) {
+    private lateinit var initialFormStatus: EditFormState
+
+    fun getFeedData(
+        feedId: Long,
+        moodItems: List<MoodItem>,
+        from: String
+    ) {
         viewModelScope.launch {
-            getFeedDataUseCase(feedId)?.let { feedEntity ->
+            getFeedDataUseCase(feedId, from)?.let { feedEntity ->
                 updateInitialFormState(moodItems, feedEntity)
             } ?: Log.e(TAG, "feed data is null")
         }
@@ -64,27 +93,34 @@ class EditViewModel @Inject constructor(
         feedEntity: MyFeedEntity
     ) {
         _formState.update { currentForm ->
-            currentForm.copy(
-                currentMood = moodItems.find { it.postData == feedEntity.writerEmotion },
-                postText = feedEntity.bodyText,
-                images = feedEntity.photo.map {
-                    Uri.parse(it)
-                },
-                existingUrl = feedEntity.photo,
-                isOpened = feedEntity.isOpened,
-                isAnonymous = feedEntity.isAnonymous,
-                sympathyMoodItems = getCurrentSympathyItems(
-                    isHappySelected = feedEntity.isHappinessSelected,
-                    isSadSelected = feedEntity.isSadnessSelected,
-                    isSurprisedSelected = feedEntity.isSurprisedSelected,
-                    isAngrySelected = feedEntity.isAngrySelected,
-                    moodItems = moodItems
-                )
-            )
+            editFormState(currentForm, moodItems, feedEntity)
         }
 
+        initialFormStatus = formState.value
         Log.i(TAG, "updateInitialFormState: form state : ${formState.value}")
     }
+
+    private fun editFormState(
+        currentForm: EditFormState,
+        moodItems: List<MoodItem>,
+        feedEntity: MyFeedEntity
+    ) = currentForm.copy(
+        storyId = feedEntity.storyId,
+        currentMood = moodItems.find { it.postData == feedEntity.writerEmotion },
+        postText = feedEntity.bodyText,
+        images = feedEntity.photo.map { Uri.parse(it) },
+        existingUrl = feedEntity.photo,
+        existingUrlId = feedEntity.photoId ?: emptyList(),
+        isOpened = feedEntity.isOpened,
+        isAnonymous = feedEntity.isAnonymous,
+        sympathyMoodItems = getCurrentSympathyItems(
+            isHappySelected = feedEntity.isHappinessSelected,
+            isSadSelected = feedEntity.isSadnessSelected,
+            isSurprisedSelected = feedEntity.isSurprisedSelected,
+            isAngrySelected = feedEntity.isAngrySelected,
+            moodItems = moodItems
+        )
+    )
 
     private fun getCurrentSympathyItems(
         isHappySelected: Boolean,
@@ -122,6 +158,153 @@ class EditViewModel @Inject constructor(
         return sympathyItems
     }
 
+    fun submitPost() {
+        viewModelScope.launch {
+            uiState = uiState.copy(isLoading = true)
+            if (isFormValid) {
+                val postImages = formState.value.images.filter {
+                    it.toString() !in formState.value.existingUrl
+                }
+                val multipartList = multipartConverter.convertUriIntoMultipart(postImages)
+                val requestBody = multipartConverter.getEditRequestBodyData(formState.value)
+
+                requestSubmit(requestBody, multipartList)
+            }
+        }
+    }
+
+    private suspend fun requestSubmit(
+        requestBody: RequestBody?,
+        multipartList: List<MultipartBody.Part>?
+    ) {
+        requestBody?.let {
+            val result = editPostUseCase(requestBody, multipartList)
+
+            when (result) {
+                is Resource.Success -> {
+                    uiState = uiState.copy(isLoading = false)
+                    postingEventChannel.send(PostingEvent.NavigateUp)
+                }
+
+                is Resource.Error -> {
+                    uiState = uiState.copy(isLoading = false, errorMessage = result.message)
+                    postingEventChannel.send(
+                        PostingEvent.Error(
+                            result.message
+                                ?: "예상치 못한 오류가 발생했습니다."
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    fun onEvent(event: EditFormEvent) {
+        when (event) {
+            is EditFormEvent.CurrentMoodChanged -> {
+                val previousMood = formState.value.currentMood
+                val selectedMood = event.mood
+                val currentSympathyItems = formState.value.sympathyMoodItems.toMutableList()
+
+                val isOpen = formState.value.isOpened
+                if (isOpen && selectedMood !in currentSympathyItems) currentSympathyItems.add(selectedMood)
+
+                previousMood?.let {
+                    val isPreviousItemRemovalValid = it in currentSympathyItems && it != selectedMood
+                    if (isPreviousItemRemovalValid) currentSympathyItems.remove(it)
+                }
+
+                _formState.value = formState.value.copy(
+                    currentMood = selectedMood,
+                    isCurrentMoodValid = validateCurrentMoodUseCase(selectedMood).isValid,
+                    sympathyMoodItems = currentSympathyItems,
+                    isSympathyMoodItemsValid = validateSympathyUseCase(isOpen, currentSympathyItems).isValid
+                )
+
+                isChanged()
+            }
+            is EditFormEvent.ImageListUpdated -> {
+                val uris = event.images
+                val isValid = validatePostImagesUseCase(uris).isValid
+                _formState.value = formState.value.copy(
+                    images = uris ?: emptyList(),
+                    isImageListValid = isValid
+                )
+
+                isChanged()
+            }
+            is EditFormEvent.PostTextChanged -> {
+                val postText = event.text
+                val isValid = validatePostTextUseCase(postText).isValid
+                _formState.value = formState.value.copy(
+                    postText = postText,
+                    isPostTextValid = isValid
+                )
+
+                isChanged()
+            }
+            is EditFormEvent.OpenChanged -> {
+                _formState.value = formState.value.copy(
+                    isOpened = event.open
+                )
+                if (!formState.value.isOpened) {
+                    _formState.value = formState.value.copy(
+                        isAnonymous = false,
+                        sympathyMoodItems = emptyList()
+                    )
+                } else {
+                    val currentMood = formState.value.currentMood
+                    currentMood?.let {
+                        _formState.value = formState.value.copy(
+                            sympathyMoodItems = listOf(currentMood)
+                        )
+                    }
+                }
+
+                isChanged()
+            }
+            is EditFormEvent.AnonymousChanged -> {
+                _formState.value = formState.value.copy(
+                    isAnonymous = event.anonymous
+                )
+
+                isChanged()
+            }
+            is EditFormEvent.SympathyItemsChanged -> {
+                val sympathyItems = event.sympathyItems
+                val isValid = validateSympathyUseCase(formState.value.isOpened, sympathyItems).isValid
+                val currentMood = formState.value.currentMood
+                currentMood?.let {
+                    if (currentMood !in sympathyItems) {
+                        return
+                    }
+                }
+                _formState.value = formState.value.copy(
+                    sympathyMoodItems = sympathyItems,
+                    isSympathyMoodItemsValid = isValid
+                )
+
+                isChanged()
+            }
+            is EditFormEvent.DialogVisibilityChanged -> {
+                _formState.value = formState.value.copy(
+                    isDialogVisible = event.isVisible
+                )
+            }
+            is EditFormEvent.DeletedUrlIdAdded -> {
+                _formState.value = formState.value.copy(
+                    deletedUrlId = (formState.value.deletedUrlId + event.urlIds).toSet().toList()
+                )
+                Log.i(TAG, "onEvent: image deleted: ${formState.value.deletedUrlId}")
+
+                isChanged()
+            }
+        }
+    }
+
+    private fun isChanged() {
+        isChanged.value = initialFormStatus != formState.value
+    }
 
     companion object {
         private const val TAG = "EditViewModel"

--- a/post/post-presentation/src/main/java/com/sowhat/post_presentation/navigation/PostNavigation.kt
+++ b/post/post-presentation/src/main/java/com/sowhat/post_presentation/navigation/PostNavigation.kt
@@ -1,11 +1,16 @@
 package com.sowhat.post_presentation.navigation
 
+import android.util.Log
 import androidx.lifecycle.Lifecycle
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import com.sowhat.common.navigation.FEED_EDIT
 import com.sowhat.common.navigation.POST
+import com.sowhat.post_presentation.edit.EditRoute
 import com.sowhat.post_presentation.posting.PostRoute
 
 fun NavGraphBuilder.postScreen(
@@ -19,5 +24,23 @@ fun NavGraphBuilder.postScreen(
 fun NavController.navigateBack() {
     if (this.currentBackStackEntry?.lifecycle?.currentState == Lifecycle.State.RESUMED) {
         this.popBackStack()
+    }
+}
+
+fun NavGraphBuilder.editFeedScreen(
+    appNavController: NavHostController
+) {
+    composable(
+        route = "$FEED_EDIT/{feedId}",
+        arguments = listOf(navArgument("feedId") { type = NavType.LongType })
+    ) { backStackEntry ->
+        val feedId = backStackEntry.arguments?.getLong("feedId")
+        Log.i("FeedEdit", "editFeedScreen: feed id : $feedId")
+        feedId?.let {
+            EditRoute(
+                navController = appNavController,
+                feedId = feedId
+            )
+        }
     }
 }

--- a/post/post-presentation/src/main/java/com/sowhat/post_presentation/navigation/PostNavigation.kt
+++ b/post/post-presentation/src/main/java/com/sowhat/post_presentation/navigation/PostNavigation.kt
@@ -31,15 +31,20 @@ fun NavGraphBuilder.editFeedScreen(
     appNavController: NavHostController
 ) {
     composable(
-        route = "$FEED_EDIT/{feedId}",
-        arguments = listOf(navArgument("feedId") { type = NavType.LongType })
+        route = "$FEED_EDIT/{from}/{feedId}",
+        arguments = listOf(
+            navArgument("from") { type = NavType.StringType },
+            navArgument("feedId") { type = NavType.LongType }
+        )
     ) { backStackEntry ->
         val feedId = backStackEntry.arguments?.getLong("feedId")
+        val from = backStackEntry.arguments?.getString("from")
         Log.i("FeedEdit", "editFeedScreen: feed id : $feedId")
-        feedId?.let {
+        if (feedId != null && from != null) {
             EditRoute(
                 navController = appNavController,
-                feedId = feedId
+                feedId = feedId,
+                from = from
             )
         }
     }

--- a/post/post-presentation/src/main/java/com/sowhat/post_presentation/posting/PostViewModel.kt
+++ b/post/post-presentation/src/main/java/com/sowhat/post_presentation/posting/PostViewModel.kt
@@ -57,7 +57,7 @@ class PostViewModel @Inject constructor(
             uiState = uiState.copy(isLoading = true)
             if (isFormValid) {
                 val multipartList = multipartConverter.convertUriIntoMultipart(formState.images)
-                val requestBody = multipartConverter.getRequestBodyData(formState)
+                val requestBody = multipartConverter.getPostRequestBodyData(formState)
 
                 requestSubmit(requestBody, multipartList)
             }

--- a/post/post-presentation/src/main/java/com/sowhat/post_presentation/posting/PostViewModel.kt
+++ b/post/post-presentation/src/main/java/com/sowhat/post_presentation/posting/PostViewModel.kt
@@ -56,7 +56,7 @@ class PostViewModel @Inject constructor(
         viewModelScope.launch {
             uiState = uiState.copy(isLoading = true)
             if (isFormValid) {
-                val multipartList = multipartConverter.convertUriIntoMultipart(formState.images)
+                val multipartList = multipartConverter.convertUriIntoMultipart(formState.images, PARTNAME_IMG)
                 val requestBody = multipartConverter.getPostRequestBodyData(formState)
 
                 requestSubmit(requestBody, multipartList)
@@ -172,5 +172,9 @@ class PostViewModel @Inject constructor(
                 )
             }
         }
+    }
+
+    companion object {
+        private const val PARTNAME_IMG = "storyImg"
     }
 }

--- a/post/post-presentation/src/main/java/com/sowhat/post_presentation/util/MultipartConverter.kt
+++ b/post/post-presentation/src/main/java/com/sowhat/post_presentation/util/MultipartConverter.kt
@@ -5,11 +5,14 @@ import android.net.Uri
 import android.util.Log
 import com.sowhat.common.util.getImageMultipartBody
 import com.sowhat.network.util.getRequestBody
+import com.sowhat.post_presentation.common.EditFormState
+import com.sowhat.post_presentation.common.EditRequest
 import com.sowhat.post_presentation.common.PostFormState
 import com.sowhat.post_presentation.common.PostRequest
 import dagger.hilt.android.qualifiers.ApplicationContext
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
+import java.lang.NullPointerException
 import javax.inject.Inject
 
 class MultipartConverter @Inject constructor(
@@ -34,13 +37,33 @@ class MultipartConverter @Inject constructor(
         }
     }
 
-    fun getRequestBodyData(formState: PostFormState): RequestBody? = try {
+    fun getPostRequestBodyData(formState: PostFormState): RequestBody? = try {
         val requestBody = PostRequest(
             anonymous = formState.isAnonymous,
             content = formState.postText,
             emotion = formState.currentMood?.postData ?: throw Exception("현재 감정이 없습니다."),
             emotionOfEmpathy = formState.sympathyMoodItems.map { it.postData },
             opened = formState.isOpened
+        )
+
+        val requestPart = getRequestBody(requestBody)
+        Log.i(TAG, requestBody.toString())
+
+        requestPart
+    } catch (e: Exception) {
+        Log.e(TAG, "requestbody를 변환하지 못하였습니다. ${e.localizedMessage}")
+        null
+    }
+
+    fun getEditRequestBodyData(formState: EditFormState): RequestBody? = try {
+        val requestBody = EditRequest(
+            anonymous = formState.isAnonymous,
+            content = formState.postText,
+            emotion = formState.currentMood?.postData ?: throw Exception("현재 감정이 없습니다."),
+            emotionOfEmpathy = formState.sympathyMoodItems.map { it.postData },
+            opened = formState.isOpened,
+            removedPhoto = formState.deletedUrlId,
+            storyId = formState.storyId ?: throw Exception("아이디가 없습니다.")
         )
 
         val requestPart = getRequestBody(requestBody)

--- a/post/post-presentation/src/main/java/com/sowhat/post_presentation/util/MultipartConverter.kt
+++ b/post/post-presentation/src/main/java/com/sowhat/post_presentation/util/MultipartConverter.kt
@@ -18,15 +18,16 @@ import javax.inject.Inject
 class MultipartConverter @Inject constructor(
     @ApplicationContext private val context: Context
 ) {
-    fun convertUriIntoMultipart(uris: List<Uri>): List<MultipartBody.Part>? {
+    fun convertUriIntoMultipart(uris: List<Uri>, multipartName: String): List<MultipartBody.Part>? {
         try {
+            Log.i(TAG, "convertUriIntoMultipart: uri list : $uris")
             if (uris.isEmpty()) return null
 
             val multipartBodyList = mutableListOf<MultipartBody.Part>()
 
             uris.forEach {
                 val currentTime = System.currentTimeMillis().toString()
-                val file = getImageMultipartBody(context, it, STORY_IMG, "${currentTime}.jpg")
+                val file = getImageMultipartBody(context, it, multipartName, "${currentTime}.jpg")
                 multipartBodyList.add(file)
             }
 

--- a/report/report-data/src/main/java/com/sowhat/report_data/repository/ReportRepositoryImpl.kt
+++ b/report/report-data/src/main/java/com/sowhat/report_data/repository/ReportRepositoryImpl.kt
@@ -72,10 +72,11 @@ class ReportRepositoryImpl(
                 profileImg = feed.profileInfo.profileImg,
                 bodyText = feed.storyMainContent.bodyText,
                 photo = feed.storyMainContent.photo.map { it.photoUrl },
+                photoId = feed.storyMainContent.photo.map { it.photoId },
                 writerEmotion = feed.storyMainContent.writerEmotion,
                 isAnonymous = feed.storyMetaInfo.isAnonymous,
                 isModified = feed.storyMetaInfo.isModified,
-                isOpened = feed.storyMetaInfo.isOpened
+                isOpened = feed.storyMetaInfo.isOpened,
             )
         }
 

--- a/report/report-presentation/src/main/java/com/sowhat/report_presentation/mypage/MyPageScreen.kt
+++ b/report/report-presentation/src/main/java/com/sowhat/report_presentation/mypage/MyPageScreen.kt
@@ -64,6 +64,7 @@ import com.sowhat.report_presentation.common.toDate
 import com.sowhat.report_presentation.component.MyFeed
 import com.sowhat.report_presentation.component.RailBackground
 import com.sowhat.report_presentation.component.Report
+import com.sowhat.report_presentation.navigation.navigateToEditScreen
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -97,7 +98,10 @@ fun MyPageRoute(
         reportUiState = reportUiState,
         onReportEvent = viewModel::onReportEvent,
         onDelete = viewModel::deleteFeed,
-        onMoodSubmit = viewModel::postNewMood
+        onMoodSubmit = viewModel::postNewMood,
+        onEdit = { feedId ->
+            navController.navigateToEditScreen(feedId)
+        }
     )
 
     ObserveEvents(flow = viewModel.postNewMoodEvent) { isSuccessful ->
@@ -142,7 +146,8 @@ fun MyPageScreen(
     onMyFeedEvent: (MyFeedEvent) -> Unit,
     onReportEvent: (ReportEvent) -> Unit,
     onDelete: (Long) -> Unit,
-    onMoodSubmit: (Mood?) -> Unit
+    onMoodSubmit: (Mood?) -> Unit,
+    onEdit: (Long) -> Unit
 ) {
     Scaffold(
         modifier = modifier.fillMaxSize()
@@ -180,7 +185,8 @@ fun MyPageScreen(
                 modifier = Modifier,
                 myFeedUiState = myFeedUiState,
                 onMyFeedEvent = onMyFeedEvent,
-                pagingData = pagingData
+                pagingData = pagingData,
+                onEdit = onEdit
             )
         }
     }
@@ -218,7 +224,8 @@ private fun MyFeedItemsScreen(
     modifier: Modifier = Modifier,
     myFeedUiState: MyFeedUiState,
     onMyFeedEvent: (MyFeedEvent) -> Unit,
-    pagingData: LazyPagingItems<MyFeedEntity>
+    pagingData: LazyPagingItems<MyFeedEntity>,
+    onEdit: (Long) -> Unit,
 ) {
     Column(
         modifier = modifier.fillMaxWidth()
@@ -284,7 +291,8 @@ private fun MyFeedItemsScreen(
                 currentDate = myFeed.createdAt.toDate()
             },
             myFeedUiState = myFeedUiState,
-            onMyFeedEvent = onMyFeedEvent
+            onMyFeedEvent = onMyFeedEvent,
+            onEdit = onEdit
         )
     }
 }
@@ -300,7 +308,8 @@ private fun MyFeedList(
     isItemIconVisible: State<Boolean>,
     onFirstItemIndexChange: (MyFeedEntity) -> Unit,
     myFeedUiState: MyFeedUiState,
-    onMyFeedEvent: (MyFeedEvent) -> Unit
+    onMyFeedEvent: (MyFeedEvent) -> Unit,
+    onEdit: (Long) -> Unit,
 ) {
     RailBackground(
         lazyListState = lazyListState,
@@ -317,15 +326,16 @@ private fun MyFeedList(
             exit = fadeOut(animationSpec = TweenSpec(durationMillis = 1000))
         ) {
             MyFeedListContent(
-                lazyListState,
-                pagingData,
-                onFirstItemIndexChange,
-                isItemIconVisible,
-                onMyFeedEvent,
-                currentDate,
-                moodItems,
-                isScrollInProgress,
-                myFeedUiState
+                lazyListState = lazyListState,
+                pagingData = pagingData,
+                onFirstItemIndexChange = onFirstItemIndexChange,
+                isItemIconVisible = isItemIconVisible,
+                onMyFeedEvent = onMyFeedEvent,
+                currentDate = currentDate,
+                moodItems = moodItems,
+                isScrollInProgress = isScrollInProgress,
+                myFeedUiState = myFeedUiState,
+                onEdit = onEdit
             )
         }
     }
@@ -341,7 +351,8 @@ private fun MyFeedListContent(
     currentDate: String?,
     moodItems: List<Mood>,
     isScrollInProgress: Boolean,
-    myFeedUiState: MyFeedUiState
+    myFeedUiState: MyFeedUiState,
+    onEdit: (Long) -> Unit
 ) {
 //    LaunchedEffect(key1 = myFeedUiState.emotion, key2 = myFeedUiState.sortBy) {
 //        Log.i("MyPage", "paging data changed")
@@ -366,16 +377,17 @@ private fun MyFeedListContent(
 
             item?.let { myFeed ->
                 FeedItem(
-                    lazyListState,
-                    index,
-                    onFirstItemIndexChange,
-                    myFeed,
-                    isItemIconVisible,
-                    item,
-                    onMyFeedEvent,
-                    currentDate,
-                    moodItems,
-                    isScrollInProgress
+                    lazyListState = lazyListState,
+                    index = index,
+                    onFirstItemIndexChange = onFirstItemIndexChange,
+                    myFeed = myFeed,
+                    isItemIconVisible = isItemIconVisible,
+                    item = item,
+                    onMyFeedEvent = onMyFeedEvent,
+                    currentDate = currentDate,
+                    moodItems = moodItems,
+                    isScrollInProgress = isScrollInProgress,
+                    onEdit = onEdit
                 )
             }
 
@@ -404,7 +416,8 @@ private fun FeedItem(
     onMyFeedEvent: (MyFeedEvent) -> Unit,
     currentDate: String?,
     moodItems: List<Mood>,
-    isScrollInProgress: Boolean
+    isScrollInProgress: Boolean,
+    onEdit: (Long) -> Unit
 ) {
     if (remember { derivedStateOf { lazyListState.firstVisibleItemIndex } }.value == index) {
         onFirstItemIndexChange(myFeed)
@@ -428,7 +441,8 @@ private fun FeedItem(
             postData = myFeed.storyId,
             contentColor = JustSayItTheme.Colors.mainTypo,
             onItemClick = {
-                // TODO 수정 화면으로 이동
+                Log.i("MyPage", "FeedItem: ${myFeed.storyId}")
+                onEdit(myFeed.storyId)
             }
         ),
         PopupMenuItem(
@@ -461,7 +475,7 @@ private fun FeedItem(
         onMenuItemClick = {
             isPopupMenuVisible = false
             it.onItemClick?.let { it() }
-        }
+        },
     )
 }
 

--- a/report/report-presentation/src/main/java/com/sowhat/report_presentation/navigation/ReportNavigation.kt
+++ b/report/report-presentation/src/main/java/com/sowhat/report_presentation/navigation/ReportNavigation.kt
@@ -32,7 +32,7 @@ fun NavGraphBuilder.myScreen(
 }
 
 fun NavController.navigateToEditScreen(feedId: Long) {
-    this.navigate("$FEED_EDIT/$feedId") {
+    this.navigate("$FEED_EDIT/$MY/$feedId") {
         launchSingleTop = true
     }
 }

--- a/report/report-presentation/src/main/java/com/sowhat/report_presentation/navigation/ReportNavigation.kt
+++ b/report/report-presentation/src/main/java/com/sowhat/report_presentation/navigation/ReportNavigation.kt
@@ -3,9 +3,11 @@ package com.sowhat.report_presentation.navigation
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
 import androidx.compose.material3.SnackbarHostState
+import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
+import com.sowhat.common.navigation.FEED_EDIT
 import com.sowhat.common.navigation.MY
 import com.sowhat.common.navigation.ONBOARDING
 import com.sowhat.report_presentation.mypage.MyPageRoute
@@ -26,5 +28,11 @@ fun NavGraphBuilder.myScreen(
         popExitTransition = null
     ) {
         MyPageRoute(navController = appNavController, snackbarHostState = snackbarHostState)
+    }
+}
+
+fun NavController.navigateToEditScreen(feedId: Long) {
+    this.navigate("$FEED_EDIT/$feedId") {
+        launchSingleTop = true
     }
 }


### PR DESCRIPTION
* 피드 수정 기능 추가
* 전체 피드 및 마이페이지 메뉴에서 수정 화면으로 이동하기 위한 로직 구현
  * 화면으로 넘어갈 시 path 변수로서 피드의 id를 넘겨줌
  * 수정 화면에서는 피드의 id를 바탕으로 데이터베이스에서 데이터를 가져와서 기존의 데이터들을 렌더링
* uri를 멀티파트 리스트로 바꾸는 함수 : 멀티파트의 이름 매개변수 추가
* 수정 비즈니스 로직 제작 및 api 연동