### PR TITLE
🐛 Fix: resolve flickering problem and scroll position problem by using paging3

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+justsayit

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,123 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <JetCodeStyleSettings>
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </JetCodeStyleSettings>
+    <codeStyleSettings language="XML">
+      <option name="FORCE_REARRANGE_MODE" value="1" />
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
+      <arrangement>
+        <rules>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:android</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>xmlns:.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:id</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*:name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>name</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>style</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>^$</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>ANDROID_ATTRIBUTE_ORDER</order>
+            </rule>
+          </section>
+          <section>
+            <rule>
+              <match>
+                <AND>
+                  <NAME>.*</NAME>
+                  <XML_ATTRIBUTE />
+                  <XML_NAMESPACE>.*</XML_NAMESPACE>
+                </AND>
+              </match>
+              <order>BY_NAME</order>
+            </rule>
+          </section>
+        </rules>
+      </arrangement>
+    </codeStyleSettings>
+    <codeStyleSettings language="kotlin">
+      <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetDropDown">
+    <value>
+      <entry key="app">
+        <State />
+      </entry>
+    </value>
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -16,10 +16,8 @@
             </builds>
           </compositeBuild>
         </compositeConfiguration>
-        <option name="testRunner" value="GRADLE" />
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="jbr-17" />
+        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
@@ -64,6 +62,7 @@
             <option value="$PROJECT_DIR$/user/user-presentation" />
           </set>
         </option>
+        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/migrations.xml
+++ b/.idea/migrations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectMigrations">
+    <option name="MigrateToGradleLocalJavaHome">
+      <set>
+        <option value="$PROJECT_DIR$" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/core/common/src/main/java/com/sowhat/common/util/LazyListStateForPagingItems.kt
+++ b/core/common/src/main/java/com/sowhat/common/util/LazyListStateForPagingItems.kt
@@ -1,0 +1,19 @@
+package com.sowhat.common.util
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.paging.compose.LazyPagingItems
+
+@Composable
+fun <T : Any> LazyPagingItems<T>.rememberLazyListState(): LazyListState {
+    // After recreation, LazyPagingItems first return 0 items, then the cached items.
+    // This behavior/issue is resetting the LazyListState scroll position.
+    // Below is a workaround. More info: https://issuetracker.google.com/issues/177245496.
+    return when (itemCount) {
+        // Return a different LazyListState instance.
+        0 -> remember(this) { LazyListState(0, 0) }
+        // Return rememberLazyListState (normal case).
+        else -> androidx.compose.foundation.lazy.rememberLazyListState()
+    }
+}

--- a/core/database/src/main/java/com/sowhat/database/dao/EntireFeedDao.kt
+++ b/core/database/src/main/java/com/sowhat/database/dao/EntireFeedDao.kt
@@ -13,6 +13,9 @@ interface EntireFeedDao {
     @Query("SELECT * FROM entire_feed")
     fun getAllFeedItems(): PagingSource<Int, EntireFeedEntity>
 
+    @Query("SELECT * FROM entire_feed")
+    fun getAllFeedEntities(): List<EntireFeedEntity>
+
     @Query("SELECT * FROM entire_feed WHERE storyId=:storyId")
     suspend fun getFeedItemByFeedId(storyId: Long): EntireFeedEntity
 

--- a/core/database/src/main/java/com/sowhat/database/dao/MyFeedDao.kt
+++ b/core/database/src/main/java/com/sowhat/database/dao/MyFeedDao.kt
@@ -13,6 +13,9 @@ interface MyFeedDao {
     @Query("SELECT * FROM my_feed")
     fun getAllMyFeedItems(): PagingSource<Int, MyFeedEntity>
 
+    @Query("SELECT * FROM my_feed")
+    fun getAllMyFeedEntityItems(): List<MyFeedEntity>
+
     @Query("SELECT * FROM my_feed WHERE storyId=:storyId")
     suspend fun getFeedItemByFeedId(storyId: Long): MyFeedEntity
 

--- a/core/designsystem/src/main/java/com/sowhat/designsystem/component/AppBar.kt
+++ b/core/designsystem/src/main/java/com/sowhat/designsystem/component/AppBar.kt
@@ -234,7 +234,7 @@ fun AppBar(
             }
         },
         actions = {
-            val textColor = if (isValid) textStyle.color else Gray500
+            val textColor = if (isValid) JustSayItTheme.Colors.mainTypo else Gray500
             actionText?.let {
                 DefaultTextButton(
                     text = actionText,

--- a/feed/feed-presentation/src/main/java/com/sowhat/feed_presentation/feeds/FeedScreen.kt
+++ b/feed/feed-presentation/src/main/java/com/sowhat/feed_presentation/feeds/FeedScreen.kt
@@ -32,9 +32,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleOwner
 import androidx.navigation.NavController
 import androidx.paging.LoadState
 import androidx.paging.PagingData
@@ -46,6 +50,7 @@ import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 import com.sowhat.database.entity.EntireFeedEntity
 import com.sowhat.common.model.UiState
 import com.sowhat.common.util.ObserveEvents
+import com.sowhat.common.util.rememberLazyListState
 import com.sowhat.designsystem.common.MOOD_ANGRY
 import com.sowhat.designsystem.common.MOOD_HAPPY
 import com.sowhat.designsystem.common.MOOD_SAD
@@ -86,6 +91,7 @@ fun FeedRoute(
     val feedPagingData = viewModel.entireFeedData.collectAsLazyPagingItems()
     val uiState = viewModel.uiState.collectAsState().value
     val scope = rememberCoroutineScope()
+    val lifecycleOwner = LocalLifecycleOwner.current
 
     val blockSuccessMessage = stringResource(id = R.string.snackbar_block_successful)
     val blockFailureMessage = stringResource(id = R.string.snackbar_block_failure)
@@ -96,6 +102,23 @@ fun FeedRoute(
     val postEmpathyError = stringResource(id = R.string.snackbar_post_empathy_error)
     val postEmpathySuccessful = stringResource(id = R.string.snackbar_post_empathy_successful)
     val cancelEmpathySuccessful = stringResource(id = R.string.snackbar_cancel_empathy_successful)
+
+    LaunchedEffect(key1 = lifecycleOwner.lifecycle.currentState) {
+        when (lifecycleOwner.lifecycle.currentState) {
+            Lifecycle.State.CREATED -> {
+                Log.i("FeedRoute", "FeedRoute: created")
+            }
+            Lifecycle.State.STARTED -> {
+                Log.i("FeedRoute", "FeedRoute: started")
+            }
+            Lifecycle.State.RESUMED -> {
+                Log.i("FeedRoute", "FeedRoute: resumed")
+            }
+            else -> {
+//                Log.i("FeedRoute", "FeedRoute: ${lifecycleOwner.lifecycle.currentState}")
+            }
+        }
+    }
 
     LaunchedEffect(key1 = isPosted) {
         if (isPosted?.value == true) {
@@ -293,13 +316,9 @@ fun FeedScreen(
     empathyEvent: Flow<PostResult>,
 ) {
     TopAppBarDefaults.enterAlwaysScrollBehavior()
-    val lazyListState = rememberLazyListState()
+    val lazyListState = feedPagingData.rememberLazyListState()
     val scope = rememberCoroutineScope()
-
-    val swipeRefreshState = rememberSwipeRefreshState(
-        isRefreshing = false
-
-    )
+    val swipeRefreshState = rememberSwipeRefreshState(isRefreshing = false)
 
     Scaffold(
         modifier = modifier
@@ -312,6 +331,7 @@ fun FeedScreen(
                 .fillMaxSize()
                 .background(JustSayItTheme.Colors.mainBackground)
         )
+
         SwipeRefresh(
             state = swipeRefreshState,
             onRefresh = {
@@ -431,19 +451,12 @@ fun FeedScreen(
                 }
 
                 item {
-//                if (feedLazyPagingItems.loadState.append is LoadState.Loading) {
-//                    AppendingCircularProgress(
-//                        modifier = Modifier
-//                            .padding(vertical = JustSayItTheme.Spacing.spaceBase)
-//                    )
-//                } else {
                     Spacer(
                         modifier = Modifier
                             .height(JustSayItTheme.Spacing.spaceExtraExtraLarge)
                             .fillMaxWidth()
                             .background(JustSayItTheme.Colors.mainBackground)
                     )
-//                }
                 }
             }
         }

--- a/feed/feed-presentation/src/main/java/com/sowhat/feed_presentation/feeds/FeedScreen.kt
+++ b/feed/feed-presentation/src/main/java/com/sowhat/feed_presentation/feeds/FeedScreen.kt
@@ -100,6 +100,7 @@ fun FeedRoute(
     LaunchedEffect(key1 = isPosted) {
         if (isPosted?.value == true) {
             Log.i("MyPageRoute", "MyPageRoute: posted")
+            viewModel.refreshFeeds()
             feedPagingData.refresh()
             navController.currentBackStackEntry
                 ?.savedStateHandle

--- a/feed/feed-presentation/src/main/java/com/sowhat/feed_presentation/feeds/FeedViewModel.kt
+++ b/feed/feed-presentation/src/main/java/com/sowhat/feed_presentation/feeds/FeedViewModel.kt
@@ -63,6 +63,11 @@ class FeedViewModel @Inject constructor(
     private val empathyEventChannel = Channel<PostResult>()
     val empathyEvent = empathyEventChannel.receiveAsFlow()
 
+    override fun onCleared() {
+        super.onCleared()
+        Log.i("FeedViewModel", "onCleared")
+    }
+
     @OptIn(ExperimentalCoroutinesApi::class)
     val entireFeedData = combine(sortBy, emotion) { s, e ->
         Log.i("FeedScreen", "Feed: $s, $e")

--- a/report/report-domain/src/main/java/com/sowhat/report_domain/FeedRemoteMediator.kt
+++ b/report/report-domain/src/main/java/com/sowhat/report_domain/FeedRemoteMediator.kt
@@ -44,16 +44,21 @@ class FeedRemoteMediator(
                 LoadType.REFRESH -> {
                     Log.i("FeedMediator", "load refresh: true")
                     // ***중요 : refresh될 때 스크롤 위치 이슈 해결 : 데이터 로드를 위해 로드키를 불러오는 과정에서 모든 데이터를 지워준다
-                    dao.deleteAllMyFeedItems()
+//                    dao.deleteAllMyFeedItems()
                     null
                 }
                 LoadType.PREPEND -> return MediatorResult.Success(endOfPaginationReached = true)
                 LoadType.APPEND -> {
-                    val lastItem = state.lastItemOrNull()
-                    lastItem?.storyId
+//                    val lastItem = state.lastItemOrNull()
+//                    lastItem?.storyId
 //                    val lastItem = dao.getNthRecord(page * state.config.pageSize - 1)
 //                    page++
 //                    lastItem?.storyId ?: return MediatorResult.Success(endOfPaginationReached = true)
+                    val lastItem = feedDatabase.withTransaction {
+                        dao.getAllMyFeedEntityItems().lastOrNull()
+                    }
+
+                    lastItem?.storyId ?: return MediatorResult.Success(endOfPaginationReached = true)
                 }
             }
 

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/edit/UpdateScreen.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/edit/UpdateScreen.kt
@@ -147,7 +147,6 @@ fun UpdateScreen(
             )
         }
     ) { paddingValues ->
-
         EditScreenContent(
             modifier = Modifier.padding(paddingValues),
             onProfileClick = onProfileClick,

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/navigation/UserNavigation.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/navigation/UserNavigation.kt
@@ -2,6 +2,7 @@ package com.sowhat.user_presentation.navigation
 
 import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.ExitTransition
+import androidx.lifecycle.Lifecycle
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
@@ -54,12 +55,14 @@ fun NavGraphBuilder.userInfoUpdateScreen(
 }
 
 fun NavController.navigateUpToSetting() {
-    // 백스택에서 현재 화면 이전, 즉 여기서는 설정 화면을 의미함. 이전 화면에 값을 저장하고자 하므로,
-    // current가 아닌 previousBackStackEntry의 savedStateHandle 사용
-    this.previousBackStackEntry
-        ?.savedStateHandle
-        ?.set("isUpdated", true)
-    this.popBackStack()
+    if (this.currentBackStackEntry?.lifecycle?.currentState == Lifecycle.State.RESUMED) {
+        // 백스택에서 현재 화면 이전, 즉 여기서는 설정 화면을 의미함. 이전 화면에 값을 저장하고자 하므로,
+        // current가 아닌 previousBackStackEntry의 savedStateHandle 사용
+        this.previousBackStackEntry
+            ?.savedStateHandle
+            ?.set("isUpdated", true)
+        this.popBackStack()
+    }
 }
 
 fun NavGraphBuilder.signOutScreen(

--- a/user/user-presentation/src/main/java/com/sowhat/user_presentation/signout/SignOutScreen.kt
+++ b/user/user-presentation/src/main/java/com/sowhat/user_presentation/signout/SignOutScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import com.sowhat.common.model.PostingEvent
@@ -84,7 +85,9 @@ private fun ScreenDialog(
             onAccept = onSignOut,
             onDismiss = {
                 onEvent(SignOutEvent.SignOutVisibilityChanged(false))
-                appNavController.popBackStack()
+                if (appNavController.currentBackStackEntry?.lifecycle?.currentState == Lifecycle.State.RESUMED) {
+                    appNavController.popBackStack()
+                }
             }
         )
     }
@@ -98,7 +101,9 @@ private fun ScreenDialog(
             onAccept = onWithdraw,
             onDismiss = {
                 onEvent(SignOutEvent.WithdrawVisibilityChanged(false))
-                appNavController.popBackStack()
+                if (appNavController.currentBackStackEntry?.lifecycle?.currentState == Lifecycle.State.RESUMED) {
+                    appNavController.popBackStack()
+                }
             }
         )
     }


### PR DESCRIPTION
* 페이징을 사용하면서 발생하였던 문제들을 해결
1. refresh 발생 시, 데이터들이 업데이트 되며 깜빡거리는 문제
* 글쓰기 화면에서 돌아왔을 때에만 데이터베이스의 모든 데이터들이 삭제되고 다시 생성되도록 조치(뷰모델의 resetFeed 함수 활용)
* 페이징을 위하여 마지막 아이템을 load 함수 차원에서 제공하는 state가 아닌 데이터베이스로부터 마지막 아이템을 쿼리하도록 변경. 이 과정에서, withTransaction함수를 꼭 써야 했는데 이 과정에서 불러오는 데이터베이스 쿼리가 여러개가 아닌 하나임에도 불구하고 왜 이 코루틴 스코프를 사용해야 하는지는 더 조사가 필요
* 기존에 loadkey를 불러오는 과정에서 refresh상태일 때 다시 한 번 데이터를 모두 지워주는 작업을 수행했는데, 이것이 깜빡임의 주 원인. 이것을 하지 않으면 페이징 라이브러리가 삭제되기 전 기존의 마지막 데이터를 로드키로 삼아서 첫 페이지 이후로는 아무것도 불러오지 못하는 문제가 있었는데, 위의 조치를 통하여 이것을 해결하였기에 해당 코드는 삭제
₩₩₩
val loadKey = when (loadType) {
                LoadType.REFRESH -> {
                    Log.i("FeedMediator", "load refresh: true")
                    //  깜빡임의 주 원인으로 삭제
//                    dao.deleteAllMyFeedItems()
                    null
                }
                LoadType.PREPEND -> return MediatorResult.Success(endOfPaginationReached = true)
                LoadType.APPEND -> {
                    val lastItem = feedDatabase.withTransaction {
                        dao.getAllMyFeedEntityItems().lastOrNull()
                    }

                    lastItem?.storyId ?: return MediatorResult.Success(endOfPaginationReached = true)
                }
            }
₩₩₩

2. 다른 화면에서 다시 돌아왔을 때, 스크롤의 위치가 유지되지 않는 문제
* 다음과 같은 헬퍼 함수를 활용하여 해결
₩₩₩
@Composable
fun <T : Any> LazyPagingItems<T>.rememberLazyListState(): LazyListState {
    // After recreation, LazyPagingItems first return 0 items, then the cached items.
    // This behavior/issue is resetting the LazyListState scroll position.
    // Below is a workaround. More info: https://issuetracker.google.com/issues/177245496.
    return when (itemCount) {
        // Return a different LazyListState instance.
        0 -> remember(this) { LazyListState(0, 0) }
        // Return rememberLazyListState (normal case).
        else -> androidx.compose.foundation.lazy.rememberLazyListState()
    }
}
₩₩₩